### PR TITLE
Limit related products data

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -208,9 +208,9 @@
 {% if page.full_url contains '/product/' %}
   {% if theme.number_related_products > 0 %}
     {% if product.categories != blank %}
-      {% for category in product.categories %}
+      {% for category in product.categories limit: 2 %}
         {% capture product_divs %}
-          {% for product in category.products %}
+          {% for product in category.products limit: 10 %}
             {% if product.id != current_id %}
               {% assign image_width = product.image.width | times: 1.0 %}
               {% assign image_height = product.image.height | times: 1.0 %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
Instead of pulling all products from all categories belonging to the current product to populate related products, this limits it to 2 categories and 10 products -- easing up on the resources being used.