### PR TITLE
feat: add theme setting to hide price of sold out products

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -97,11 +97,13 @@
                 <div class="prod-thumb-info-headers">
                   <div class="prod-thumb-name">{{ product.name }}</div>
                   <div class="prod-thumb-price">
-                    {% if product.variable_pricing %}
-                      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                    {% else %}
-                      {{ product.default_price | money: theme.money_format }}
-                    {% endif %}
+                    {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% if product.variable_pricing %}
+                        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                      {% else %}
+                        {{ product.default_price | money: theme.money_format }}
+                      {% endif %}
+                    {% endunless %}
                   </div>
                   {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
                   {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}

--- a/source/product.html
+++ b/source/product.html
@@ -10,13 +10,20 @@
 <div class="page-heading product-heading">
   <h1 class="page-title">{{ page.name }}</h1>
 </div>
-<div class="page-subheading">
+{% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+  {% assign hide_price = true %}
+{% else %}
+  {% assign hide_price = false %}
+{% endif %}
+<div class="page-subheading{% if hide_price %} page-subheading--price-hidden{% endif %}">
   <div class="page-subheading-price">
-    {% if product.variable_pricing %}
-      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-    {% else %}
-      {{ product.default_price | money: theme.money_format }}
-    {% endif %}
+    {% unless hide_price %}
+      {% if product.variable_pricing %}
+        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+      {% else %}
+        {{ product.default_price | money: theme.money_format }}
+      {% endif %}
+    {% endunless %}
   </div>
   {% if product_status != blank %}
     <div class="page-subheading-status">
@@ -301,11 +308,13 @@
                 <div class="prod-thumb-info-headers">
                   <div class="prod-thumb-name">{{ product.name }}</div>
                   <div class="prod-thumb-price">
-                    {% if product.variable_pricing %}
-                      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                    {% else %}
-                      {{ product.default_price | money: theme.money_format }}
-                    {% endif %}
+                    {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% if product.variable_pricing %}
+                        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                      {% else %}
+                        {{ product.default_price | money: theme.money_format }}
+                      {% endif %}
+                    {% endunless %}
                   </div>
                   {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
                   {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}

--- a/source/products.html
+++ b/source/products.html
@@ -119,11 +119,13 @@
               <div class="prod-thumb-info-headers">
                 <div class="prod-thumb-name">{{ product.name }}</div>
                 <div class="prod-thumb-price">
-                  {% if product.variable_pricing %}
-                    {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                  {% else %}
-                    {{ product.default_price | money: theme.money_format }}
-                  {% endif %}
+                  {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% if product.variable_pricing %}
+                      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                    {% else %}
+                      {{ product.default_price | money: theme.money_format }}
+                    {% endif %}
+                  {% endunless %}
                 </div>
                 {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
                 {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -555,10 +555,18 @@
     },
     {
       "variable": "show_sold_out_product_options",
-      "label": "Show sold out product options",
+      "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
-      "description": "Shows sold out product options in the Product page dropdowns",
+      "description": "Shows sold out product variants in the Product page dropdowns",
+      "requires": "inventory"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of sold out products on product grids and product pages",
       "requires": "inventory"
     },
     {

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -12,6 +12,9 @@
 
   @media screen and (max-width: $break-small)
     +flex-direction(column)
+  
+  &--price-hidden
+    display: block
 
 .page-subheading-status
   font-size: 14px


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/67df7d01-949b-420a-baf0-4bd8ddbe9369)
![image](https://github.com/user-attachments/assets/69bca35c-5ad6-4e5e-881f-44d53028c53b)

When price hidden set the display to be `block` on this section so the product status snaps left.

![image](https://github.com/user-attachments/assets/135ae24a-2ad0-4bbd-ab80-403745113621)