### PR TITLE
feat: add theme setting for secondary badge color and text color

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -58,6 +58,7 @@
                 image-square
               {% endif %}
             {% endcapture %}
+            {% capture status_classes %}{{ theme.product_badge_style }} {% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
             <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ product.url }}" title="View {{ product.name | escape }}">
               <div class="prod-thumb-container">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -80,7 +81,7 @@
                     "
                     data-sizes="auto"
                   >
-                  {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
+                  {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
                   {% if theme.show_quickview %}
                     <div class="product-list-quickview-container">
                       <div class="product-list-quickview-container-background"></div>
@@ -103,7 +104,7 @@
                       {{ product.default_price | money: theme.money_format }}
                     {% endif %}
                   </div>
-                  {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
+                  {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
                   {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
                     <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ product.permalink }}" data-has-default="{{ product.has_default_option }}" title="Quick view {{ product.name | escape }}">
                       <span class="open-quickview-text">Quick View</span>

--- a/source/product.html
+++ b/source/product.html
@@ -7,6 +7,7 @@
   {% when 'coming-soon' %}
     {% assign product_status = 'Coming soon' %}
 {% endcase %}
+{% capture status_classes %}{{ theme.product_badge_style }} {% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
 <div class="page-heading product-heading">
   <h1 class="page-title">{{ page.name }}</h1>
 </div>
@@ -284,7 +285,7 @@
                     "
                     data-sizes="auto"
                   >
-                  {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
+                  {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
                   {% if theme.show_quickview %}
                     <div class="product-list-quickview-container">
                       <div class="product-list-quickview-container-background"></div>
@@ -307,7 +308,7 @@
                       {{ product.default_price | money: theme.money_format }}
                     {% endif %}
                   </div>
-                  {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
+                  {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
                   {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
                     <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ product.permalink }}" data-has-default="{{ product.has_default_option }}" title="Quick view {{ product.name | escape }}">
                       <span class="open-quickview-text">Quick View</span>

--- a/source/products.html
+++ b/source/products.html
@@ -80,6 +80,7 @@
               image-square
             {% endif %}
           {% endcapture %}
+          {% capture status_classes %}{{ theme.product_badge_style }} {% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
           <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ product.url }}" title="View {{ product.name | escape }}">
             <div class="prod-thumb-container">
               <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -102,7 +103,7 @@
                   "
                   data-sizes="auto"
                 >
-                {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
+                {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
                 {% if theme.show_quickview %}
                   <div class="product-list-quickview-container">
                     <div class="product-list-quickview-container-background"></div>
@@ -125,7 +126,7 @@
                     {{ product.default_price | money: theme.money_format }}
                   {% endif %}
                 </div>
-                {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ theme.product_badge_style }}">{{ product_status }}</div>{% endif %}
+                {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
                 {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
                   <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ product.permalink }}" data-has-default="{{ product.has_default_option }}" title="Quick view {{ product.name | escape }}">
                     <span class="open-quickview-text">Quick View</span>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "images": [
     {
       "variable": "logo",
@@ -43,8 +43,10 @@
               "button_background_color": "#000000",
               "button_hover_text_color": "#FFFFFF",
               "button_hover_background_color": "#056FFA",
-              "badge_text_color": "#000000",
-              "badge_background_color": "#9AFF00",
+              "badge_text_color_primary": "#000000",
+              "badge_background_color_primary": "#9AFF00",
+              "badge_text_color_secondary": "#000000",
+              "badge_background_color_secondary": "#E0E0E0",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -63,8 +65,10 @@
               "button_background_color": "#F8F8F8",
               "button_hover_text_color": "#F8F8F8",
               "button_hover_background_color": "#4D4D4D",
-              "badge_text_color": "#F8F8F8",
-              "badge_background_color": "#141415",
+              "badge_text_color_primary": "#F8F8F8",
+              "badge_background_color_primary": "#141415",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#F8F8F8",
               "announcement_background_color": "#4D4D4D"
             }
@@ -83,8 +87,10 @@
               "button_background_color": "#203BE1",
               "button_hover_text_color": "#F8F8F8",
               "button_hover_background_color": "#2A2A2C",
-              "badge_text_color": "#F8F8FA",
-              "badge_background_color": "#203BE1",
+              "badge_text_color_primary": "#F8F8FA",
+              "badge_background_color_primary": "#203BE1",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#0C143B",
               "announcement_background_color": "#E3E4EA"
             }
@@ -108,8 +114,10 @@
               "button_background_color": "#8A4942",
               "button_hover_text_color": "#F5F4EE",
               "button_hover_background_color": "#262522",
-              "badge_text_color": "#F5F4EE",
-              "badge_background_color": "#898952",
+              "badge_text_color_primary": "#F5F4EE",
+              "badge_background_color_primary": "#898952",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#262522",
               "announcement_background_color": "#F1DBCE"
             }
@@ -128,8 +136,10 @@
               "button_background_color": "#584B53",
               "button_hover_text_color": "#FEF5EF",
               "button_hover_background_color": "#1F161B",
-              "badge_text_color": "#1F161B",
-              "badge_background_color": "#D6E3F8",
+              "badge_text_color_primary": "#1F161B",
+              "badge_background_color_primary": "#78A9F9",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#1F161B",
               "announcement_background_color": "#D6E3F8"
             }
@@ -153,8 +163,10 @@
               "button_background_color": "#0000FF",
               "button_hover_text_color": "#FFFFFF",
               "button_hover_background_color": "#000000",
-              "badge_text_color": "#FFFFFF",
-              "badge_background_color": "#0000FF",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#0000FF",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -173,8 +185,10 @@
               "button_background_color": "#F90081",
               "button_hover_text_color": "#FFFFFF",
               "button_hover_background_color": "#D1006C",
-              "badge_text_color": "#0B0423",
-              "badge_background_color": "#22FFF8",
+              "badge_text_color_primary": "#0B0423",
+              "badge_background_color_primary": "#22FFF8",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#0B0423",
               "announcement_background_color": "#F6FF20"
             }
@@ -193,8 +207,10 @@
               "button_background_color": "#000000",
               "button_hover_text_color": "#FFFFFF",
               "button_hover_background_color": "#056FFA",
-              "badge_text_color": "#000000",
-              "badge_background_color": "#9AFF00",
+              "badge_text_color_primary": "#000000",
+              "badge_background_color_primary": "#9AFF00",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -213,8 +229,10 @@
               "button_background_color": "#243588",
               "button_hover_text_color": "#243588",
               "button_hover_background_color": "#FFFA8D",
-              "badge_text_color": "#0C143B",
-              "badge_background_color": "#FFFA8D",
+              "badge_text_color_primary": "#0C143B",
+              "badge_background_color_primary": "#FFFA8D",
+              "badge_text_color_secondary": "#141415",
+              "badge_background_color_secondary": "#D8D8D8",
               "announcement_text_color": "#0C143B",
               "announcement_background_color": "#FFFA8D"
             }
@@ -238,57 +256,67 @@
     },
     {
       "variable": "text_color",
-      "label": "Text Color",
+      "label": "Text",
       "default": "#000000"
     },
     {
       "variable": "link_hover_color",
-      "label": "Link hover color",
+      "label": "Link hover",
       "default": "#056FFA"
     },
     {
       "variable": "border_color",
-      "label": "Border Color",
+      "label": "Border",
       "default": "#000000"
     },
     {
       "variable": "button_text_color",
-      "label": "Button Text Color",
+      "label": "Button text",
       "default": "#FFFFFF"
     },
     {
       "variable": "button_background_color",
-      "label": "Button Background Color",
+      "label": "Button background",
       "default": "#000000"
     },
     {
       "variable": "button_hover_text_color",
-      "label": "Button Hover Text Color",
+      "label": "Button hover text",
       "default": "#FFFFFF"
     },
     {
       "variable": "button_hover_background_color",
-      "label": "Button Hover Background Color",
+      "label": "Button hover background",
       "default": "#056FFA"
     },
     {
-      "variable": "badge_text_color",
-      "label": "Badge Text Color",
+      "variable": "badge_text_color_primary",
+      "label": "Badge text (primary)",
       "default": "#000000"
     },
     {
-      "variable": "badge_background_color",
-      "label": "Badge Background Color",
+      "variable": "badge_background_color_primary",
+      "label": "Badge background (primary)",
       "default": "#9AFF00"
     },
     {
+      "variable": "badge_text_color_secondary",
+      "label": "Badge text (secondary)",
+      "default": "#000000"
+    },
+    {
+      "variable": "badge_background_color_secondary",
+      "label": "Badge background (secondary)",
+      "default": "#E0E0E0"
+    },
+    {
       "variable": "announcement_text_color",
-      "label": "Announcement Message Text",
+      "label": "Announcement message text",
       "default": "#FFFFFF"
     },
     {
       "variable": "announcement_background_color",
-      "label": "Announcement Message Background",
+      "label": "Announcement message background",
       "default": "#000000"
     }
   ],

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -11,8 +11,11 @@ $border-color: #{"{{ theme.border_color }}"}
 $button-text-color: #{"{{ theme.button_text_color }}"}
 $button-background-color: #{"{{ theme.button_background_color }}"}
 
-$badge-text-color: #{"{{ theme.badge_text_color }}"}
-$badge-background-color: #{"{{ theme.badge_background_color }}"}
+$badge-text-color-primary: #{"{{ theme.badge_text_color_primary }}"}
+$badge-background-color-primary: #{"{{ theme.badge_background_color_primary }}"}
+$badge-text-color_secondary: #{"{{ theme.badge_text_color_secondary }}"}
+$badge-background-color-secondary: #{"{{ theme.badge_background_color_secondary }}"}
+
 
 $button-hover-text-color: #{"{{ theme.button_hover_text_color }}"}
 $button-hover-background-color: #{"{{ theme.button_hover_background_color }}"}

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -432,9 +432,9 @@ ul.sort-by-nav-links
     +flexbox
     +align-items(center)
     +justify-content(center)
-    background: $badge-background-color
+    background: $badge-background-color-primary
     border-radius: 50%
-    color: $badge-text-color
+    color: $badge-text-color-primary
     font-size: 12px
     line-height: 1.25em
     height: 64px
@@ -444,6 +444,14 @@ ul.sort-by-nav-links
     text-align: center
     top: $base-padding
     width: 64px
+
+    &.status-primary
+      background: $badge-background-color-primary
+      color: $badge-text-color-primary
+
+    &.status-secondary
+      background: $badge-background-color-secondary
+      color: $badge-text-color-secondary
 
     @media screen and (max-width: $break-small)
       font-size: 10px
@@ -457,8 +465,8 @@ ul.sort-by-nav-links
         top: $base-padding
 
   &.bar
-    background: $badge-background-color
-    color: $badge-text-color
+    background: $badge-background-color-primary
+    color: $badge-text-color-primary
     font-size: 13px
     line-height: 1em
     position: absolute


### PR DESCRIPTION
On sale badge color more prominent than other product statuses by adding a secondary badge color.

Examples

![image](https://github.com/user-attachments/assets/06d3dcc8-3592-451d-a886-111a1690b5bb)

