### PR TITLE
fix: hamburger menu color

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/vendor/hamburger.scss
+++ b/source/stylesheets/vendor/hamburger.scss
@@ -5,7 +5,7 @@ $hamburger-padding-y           : 15px !default;
 $hamburger-layer-width         : 32px !default;
 $hamburger-layer-height        : 4px !default;
 $hamburger-layer-spacing       : 4px !default;
-$hamburger-layer-color         : #{"{{ theme.text_color }}"} !default;
+$hamburger-layer-color         : #{"{{ theme.primary_text_color }}"} !default;
 $hamburger-layer-border-radius : 0px !default;
 $hamburger-hover-opacity       : 0.7 !default;
 $hamburger-active-layer-color  : $hamburger-layer-color !default;


### PR DESCRIPTION
Fixed issue with incorrect hamburger menu color introduced from change of `text_color` -> `primary_text_color`