### PR TITLE
v1.10.0

### DIFF
--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -179,19 +179,6 @@ $('body').on('click', ".description-inventory-tab", function(e){
   $('.' + tab_name).show();
 })
 
-$(document).ready(function() {
-  if ($('.all-similar-products').length) {
-    var num_products = $('.all-similar-products .prod-thumb').length;
-    var elements = $('.all-similar-products').children().toArray();
-    var num_to_display = $('.related-products-container').data('num-products');
-    for (var i=1; i<=num_to_display; i++) {
-      var randomIndex = getRandomIndex(elements);
-      $('.similar-product-list').append($('.all-similar-products').children().eq(randomIndex));
-      elements.splice(randomIndex, 1);
-      $('.similar-product-list .similar-product-list-image').each(function() {
-        $(this).attr("src",$(this).data("src"));
-      })
-    }
-    $('.all-similar-products').remove();
-  }
+document.addEventListener('DOMContentLoaded', () => {
+  updateInventoryMessage();
 });

--- a/source/javascripts/quickshop.js
+++ b/source/javascripts/quickshop.js
@@ -73,7 +73,7 @@ function showLoading(){
   $('.qs-product-container').addClass('spinner');
 }
 
-function loadProductContent(product) {
+async function loadProductContent(product) {
   var $container = $('.qs-product-details');
 
   var this_product = $(".open-quickview[data-permalink='" + product.permalink + "']").closest('.prod-thumb');
@@ -82,11 +82,23 @@ function loadProductContent(product) {
 
   openQuickShop();
 
+  if (!window.location.hostname.includes('127.0.0.1')) {
+    $.getJSON(`/product/${product.permalink}.json`)
+      .done(productData => {
+        window.bigcartel.product = productData;
+      })
+      .fail(() => {
+        window.bigcartel.product = product;
+      });
+  } else {
+    window.bigcartel.product = product;
+  }
+  
   $.get("/product/" + product.permalink + "?" + $.now(), function(response, status, xhr) {
-
     $container.html($(response).find(".main"));
     initCarousel('quickshop');
     initLightbox();
+    updateInventoryMessage();
     $('.qs-product-container').removeClass('spinner');
     $('.qs-product-container').animate({
       scrollTop: 0

--- a/source/layout.html
+++ b/source/layout.html
@@ -92,7 +92,7 @@
                 {% for page in pages.all %}
                   <li class="sidebar-nav-link">{{ page | link_to }}</li>
                 {% endfor %}
-                <li class="sidebar-nav-link"><a href="/contact">Contact</a></li>
+                <li class="sidebar-nav-link"><a href="/contact">{{ pages.contact.name }}</a></li>
               </ul>
               <div class="scroll-more"></div>
             </section>
@@ -188,14 +188,14 @@
                       {% for page in pages.all %}
                         <li class="horizontal-nav-link" role="menuitem"><a href="{{ page.url }}" tabindex="-1">{{ page.name }}</a></li></li>
                       {% endfor %}
-                      <li class="horizontal-nav-link" role="menuitem"><a href="/contact" tabindex="-1">Contact</a></li>
+                      <li class="horizontal-nav-link" role="menuitem"><a href="/contact" tabindex="-1">{{ pages.contact.name }}</a></li>
                       {% if store.website != blank %}
                         <li class="horizontal-nav-link" role="menuitem"><a href="{{ store.website }}" tabindex="-1">Back to site</a></li>
                       {% endif %}
                     </ul>
                   </li>
                 {% else %}
-                  <li class="nav-menu-item" role="menuitem" aria-haspopup="false"><a href="/contact"><span class="hover-underline no-underline">Contact</span></a></li>
+                  <li class="nav-menu-item" role="menuitem" aria-haspopup="false"><a href="/contact"><span class="hover-underline no-underline">{{ pages.contact.name }}</span></a></li>
                 {% endif %}
 
               </ul>
@@ -300,7 +300,7 @@
                 {% for page in pages.all %}
                   <li class="sidebar-nav-link medium-border">{{ page | link_to }}</li>
                 {% endfor %}
-                <li class="sidebar-nav-link medium-border"><a href="/contact">Contact</a></li>
+                <li class="sidebar-nav-link medium-border"><a href="/contact">{{ pages.contact.name }}</a></li>
                 {% if store.website != blank %}
                   <li class="sidebar-nav-link medium-border"><a href="{{ store.website }}">Back to site</a></li>
                 {% endif %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -93,9 +93,6 @@
                   <li class="sidebar-nav-link">{{ page | link_to }}</li>
                 {% endfor %}
                 <li class="sidebar-nav-link"><a href="/contact">Contact</a></li>
-                {% if store.website != blank %}
-                  <li class="sidebar-nav-link"><a href="{{ store.website }}">Back to site</a></li>
-                {% endif %}
               </ul>
               <div class="scroll-more"></div>
             </section>

--- a/source/layout.html
+++ b/source/layout.html
@@ -318,6 +318,9 @@
               or theme.facebook_url != blank
               or theme.pinterest_url != blank
               or theme.youtube_url != blank
+              or theme.spotify_url != blank
+              or theme.linkedin_url != blank
+              or theme.twitch_url != blank
               or theme.tumblr_url != blank
               or theme.bandcamp_url != blank %}
               <div class="nav-section nav-section-social">
@@ -356,6 +359,18 @@
 
                   {% if theme.youtube_url != blank %}
                     <a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg></a>
+                  {% endif %}
+
+                  {% if theme.spotify_url != blank %}
+                    <a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a>
+                  {% endif %}
+
+                  {% if theme.linkedin_url != blank %}
+                    <a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a>
+                  {% endif %}
+
+                  {% if theme.twitch_url != blank %}
+                    <a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a>
                   {% endif %}
 
                   {% if theme.tumblr_url != blank %}
@@ -401,6 +416,7 @@
             or theme.youtube_url != blank
             or theme.spotify_url != blank
             or theme.linkedin_url != blank
+            or theme.twitch_url != blank
             or theme.tumblr_url != blank
             or theme.bandcamp_url != blank %}
             <section class="footer-nav-section nav-section-social">
@@ -447,6 +463,10 @@
 
                 {% if theme.linkedin_url != blank %}
                   <a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a>
+                {% endif %}
+
+                {% if theme.twitch_url != blank %}
+                  <a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a>
                 {% endif %}
 
                 {% if theme.tumblr_url != blank %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -517,11 +517,12 @@
         primaryGradientColor: '{{ theme.background_color }}',
         hasAnnouncement: {% if theme.announcement_message_text %}true{%else %}false{%endif %},
         showSoldOutOptions: {{ theme.show_sold_out_product_options }},
+        showLowInventoryMessages: {{ theme.show_low_inventory_messages }},
+        lowInventoryMessage: '{{ theme.low_inventory_message }}',
+        almostSoldOutMessage: '{{ theme.almost_sold_out_message }}',
         desktopProductPageImages: '{{ theme.desktop_product_page_images }}',
         mobileProductPageImages: '{{ theme.mobile_product_page_images }}',
         productImageZoom: {{ theme.product_image_zoom }},
-        show
-        lowInventoryThreshold: {{ theme.low_inventory_threshold }}
       }
       var inPreview = (/http(s?):\/\/draft-+\w+\.bigcartel\.(test|biz|com)/.test(window.origin)||(/\/admin\/design/.test(top.location.pathname)));
       function setCookie(name,value,days) {

--- a/source/layout.html
+++ b/source/layout.html
@@ -402,6 +402,9 @@
 
       <footer class="footer {% if body_class contains 'has-sidebar' %}hide-desktop{% endif %}" role="contentinfo" data-bc-hook="footer">
         <nav class="footer-nav" id="footer" role="navigation" aria-label="Footer">
+          {% if theme.footer_text != blank %}
+            <div class="footer-custom-content">{{ theme.footer_text }} </div>
+          {% endif %}
           {% if theme.instagram_url != blank
             or theme.tiktok_url != blank
             or theme.bluesky_url != blank

--- a/source/layout.html
+++ b/source/layout.html
@@ -399,6 +399,8 @@
             or theme.facebook_url != blank
             or theme.pinterest_url != blank
             or theme.youtube_url != blank
+            or theme.spotify_url != blank
+            or theme.linkedin_url != blank
             or theme.tumblr_url != blank
             or theme.bandcamp_url != blank %}
             <section class="footer-nav-section nav-section-social">
@@ -437,6 +439,14 @@
 
                 {% if theme.youtube_url != blank %}
                   <a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" aria-hidden="true" width="27" height="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27 18"><path d="M23.501714 17.4615797c1.1014225-.296264 1.9688826-1.1330082 2.2633155-2.2415719.4738052-1.7797495.5279544-5.27205903.5341429-6.0470555v-.30951368c-.0061885-.77498826-.0603377-4.2672619-.5341429-6.04701143C25.4705966 1.70781777 24.6031365.8347272 23.501714.53846326c-1.7926805-.4834795-8.4305681-.53281414-9.7665731-.53784828h-.4703449c-1.3359979.00503414-7.97385278.05436879-9.76657436.53784828C2.3967991.83477298 1.52933901 1.70781777 1.23490611 2.8164272.7152488 4.76841054.70040145 8.78041249.69996476 9.00807629v.01011834s0 4.19241857.53494135 6.20181317c.2944329 1.1085637 1.16189299 1.9453079 2.26331553 2.2415719 1.75197791.4724913 8.13135846.5303474 9.66738706.5374318h.6687183c1.5360285-.0070844 7.9154091-.0649405 9.667387-.5374318zM10.881749 12.824582V5.21180722l6.6908867 3.80647896L10.881749 12.824582z" fill-rule="nonzero"/></svg></a>
+                {% endif %}
+
+                {% if theme.spotify_url != blank %}
+                  <a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a>
+                {% endif %}
+
+                {% if theme.linkedin_url != blank %}
+                  <a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a>
                 {% endif %}
 
                 {% if theme.tumblr_url != blank %}
@@ -489,7 +499,9 @@
         showSoldOutOptions: {{ theme.show_sold_out_product_options }},
         desktopProductPageImages: '{{ theme.desktop_product_page_images }}',
         mobileProductPageImages: '{{ theme.mobile_product_page_images }}',
-        productImageZoom: {{ theme.product_image_zoom }}
+        productImageZoom: {{ theme.product_image_zoom }},
+        show
+        lowInventoryThreshold: {{ theme.low_inventory_threshold }}
       }
       var inPreview = (/http(s?):\/\/draft-+\w+\.bigcartel\.(test|biz|com)/.test(window.origin)||(/\/admin\/design/.test(top.location.pathname)));
       function setCookie(name,value,days) {

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -22,6 +22,7 @@
         or theme.youtube_url != blank
         or theme.spotify_url != blank
         or theme.linkedin_url != blank
+        or theme.twitch_url != blank
         or theme.tumblr_url != blank
         or theme.bandcamp_url != blank %}
         <section class="nav-section maintenance-social-links">
@@ -68,6 +69,10 @@
 
             {% if theme.linkedin_url != blank %}
               <a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a>
+            {% endif %}
+
+            {% if theme.twitch_url != blank %}
+              <a href="{{ theme.twitch_url }}" title="Twitch"><svg class="twitch-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M391.2 103.5H352.5v109.7h38.6zM285 103H246.4V212.8H285zM120.8 0 24.3 91.4V420.6H140.1V512l96.5-91.4h77.3L487.7 256V0zM449.1 237.8l-77.2 73.1H294.6l-67.6 64v-64H140.1V36.6H449.1z"/></svg></a>
             {% endif %}
 
             {% if theme.tumblr_url != blank %}

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -20,6 +20,8 @@
         or theme.facebook_url != blank
         or theme.pinterest_url != blank
         or theme.youtube_url != blank
+        or theme.spotify_url != blank
+        or theme.linkedin_url != blank
         or theme.tumblr_url != blank
         or theme.bandcamp_url != blank %}
         <section class="nav-section maintenance-social-links">
@@ -58,6 +60,14 @@
 
             {% if theme.youtube_url != blank %}
               <a href="{{ theme.youtube_url }}" title="YouTube"><svg class="youtube-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M550 124c-7-24-25-42-49-49-42-11-213-11-213-11S117 64 75 76c-24 6-42 24-49 48-11 43-11 132-11 132s0 90 11 133c7 23 25 41 49 47 42 12 213 12 213 12s171 0 213-11c24-7 42-25 49-48 11-43 11-133 11-133s0-89-11-132zM232 338V175l143 81-143 82z"/></svg></a>
+            {% endif %}
+
+            {% if theme.spotify_url != blank %}
+              <a href="{{ theme.spotify_url }}" title="Spotify"><svg class="spotify-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M248 8C111.1 8 0 119.1 0 256s111.1 248 248 248 248-111.1 248-248S384.9 8 248 8zm100.7 364.9c-4.2 0-6.8-1.3-10.7-3.6-62.4-37.6-135-39.2-206.7-24.5-3.9 1-9 2.6-11.9 2.6-9.7 0-15.8-7.7-15.8-15.8 0-10.3 6.1-15.2 13.6-16.8 81.9-18.1 165.6-16.5 237 26.2 6.1 3.9 9.7 7.4 9.7 16.5s-7.1 15.4-15.2 15.4zm26.9-65.6c-5.2 0-8.7-2.3-12.3-4.2-62.5-37-155.7-51.9-238.6-29.4-4.8 1.3-7.4 2.6-11.9 2.6-10.7 0-19.4-8.7-19.4-19.4s5.2-17.8 15.5-20.7c27.8-7.8 56.2-13.6 97.8-13.6 64.9 0 127.6 16.1 177 45.5 8.1 4.8 11.3 11 11.3 19.7-.1 10.8-8.5 19.5-19.4 19.5zm31-76.2c-5.2 0-8.4-1.3-12.9-3.9-71.2-42.5-198.5-52.7-280.9-29.7-3.6 1-8.1 2.6-12.9 2.6-13.2 0-23.3-10.3-23.3-23.6 0-13.6 8.4-21.3 17.4-23.9 35.2-10.3 74.6-15.2 117.5-15.2 73 0 149.5 15.2 205.4 47.8 7.8 4.5 12.9 10.7 12.9 22.6 0 13.6-11 23.3-23.2 23.3z"/></svg></a>
+            {% endif %}
+
+            {% if theme.linkedin_url != blank %}
+              <a href="{{ theme.linkedin_url }}" title="LinkedIn"><svg class="linkedin-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"/></svg></a>
             {% endif %}
 
             {% if theme.tumblr_url != blank %}

--- a/source/product.html
+++ b/source/product.html
@@ -241,105 +241,153 @@
     {% endif %}
   </div>
 </div>
-{% assign current_id = product.id %}
 {% if page.full_url contains '/product/' %}
-  {% if theme.number_related_products > 0 %}
+  {% if theme.show_related_products %}
+    {% assign current_id = product.id | to_string %}
+    {% assign related_products_limit = theme.number_related_products | default: 4 %}
+    {% assign final_product_permalinks = '' %}
+    
+    {% comment %}
+    Step 1: Collect Products from Categories
+    {% endcomment %}
     {% if product.categories != blank %}
-      {% for category in product.categories limit: 2 %}
-        {% capture product_divs %}
-          {% for product in category.products limit: 10 %}
+      {% for category in product.categories limit: 4 %}
+        {% for product in category.products | order: theme.related_products_order %}
+          {% if final_product_permalinks | split: ',' | size < related_products_limit %}
+            {% assign product_permalink = product.permalink %}
             {% if product.id != current_id %}
-              {% assign image_width = product.image.width | times: 1.0 %}
-              {% assign image_height = product.image.height | times: 1.0 %}
-              {% assign aspect_ratio = image_width | divided_by: image_height %}
-              {% assign product_status = '' %}
-              {% case product.status %}
-                {% when 'active' %}
-                  {% if product.on_sale %}{% assign product_status = 'On sale' %}{% endif %}
-                {% when 'sold-out' %}
-                  {% assign product_status = 'Sold out' %}
-                {% when 'coming-soon' %}
-                  {% assign product_status = 'Coming soon' %}
-              {% endcase %}
-              {% capture image_class %}
-                {% if product.image.height > product.image.width %}
-                  image-tall
-                {% elsif product.image.height < product.image.width %}
-                  image-wide
-                {% else %}
-                  image-square
-                {% endif %}
-              {% endcapture %}
-            <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ product.url }}" title="View {{ product.name | escape }}">
-              <div class="prod-thumb-container">
-                <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                  <img
-                    alt=""
-                    class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                    src="{{ product.image | product_image_url | constrain: 20 }}"
-                    {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
-                    data-srcset="
-                      {{ product.image | product_image_url | constrain: 200 }} 200w,
-                      {{ product.image | product_image_url | constrain: 280 }} 280w,
-                      {{ product.image | product_image_url | constrain: 350 }} 350w,
-                      {{ product.image | product_image_url | constrain: 400 }} 400w,
-                      {{ product.image | product_image_url | constrain: 500 }} 500w,
-                      {{ product.image | product_image_url | constrain: 650 }} 650w,
-                      {{ product.image | product_image_url | constrain: 800 }} 800w,
-                      {{ product.image | product_image_url | constrain: 1000 }} 1000w,
-                      {{ product.image | product_image_url | constrain: 1200 }} 1200w,
-                      {{ product.image | product_image_url | constrain: 1300 }} 1300w
-                    "
-                    data-sizes="auto"
-                  >
-                  {% if product_status != blank and theme.product_badge_style != 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
-                  {% if theme.show_quickview %}
-                    <div class="product-list-quickview-container">
-                      <div class="product-list-quickview-container-background"></div>
-                      <button class="button open-quickview" data-permalink="{{ product.permalink }}" data-has-default="{{ product.has_default_option }}" title="Quick view {{ product.name | escape }}" tabindex="-1">
-                        <span class="open-quickview-text">Quick View</span>
-                        <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
-                      </button>
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
-              <div class="prod-thumb-info">
-                <div class="prod-thumb-background"></div>
-                <div class="prod-thumb-info-headers">
-                  <div class="prod-thumb-name">{{ product.name }}</div>
-                  <div class="prod-thumb-price">
-                    {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                      {% if product.variable_pricing %}
-                        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-                      {% else %}
-                        {{ product.default_price | money: theme.money_format }}
-                      {% endif %}
-                    {% endunless %}
-                  </div>
-                  {% if product_status != blank and theme.product_badge_style == 'inline' %}<div class="prod-thumb-status {{ status_classes }}">{{ product_status }}</div>{% endif %}
-                  {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
-                    <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ product.permalink }}" data-has-default="{{ product.has_default_option }}" title="Quick view {{ product.name | escape }}">
-                      <span class="open-quickview-text">Quick View</span>
-                      <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
-            </a>
+              {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+              {% unless product_permalinks_array contains product_permalink %}
+                {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+              {% endunless %}
             {% endif %}
-          {% endfor %}
-        {% endcapture %}
+          {% else %}
+            {% break %}
+          {% endif %}
+        {% endfor %}
       {% endfor %}
     {% endif %}
+    
+    {% comment %}
+    Step 2: Collect Fallback Products from products.all
+    {% endcomment %}
+    {% assign current_count = final_product_permalinks | split: ',' | size %}
+    {% assign remaining_limit = related_products_limit | minus: current_count %}
+    
+    {% if remaining_limit > 0 %}
+      {% paginate products from products.all by remaining_limit order: theme.related_products_order %}
+        {% for product in products %}
+          {% assign product_permalink = product.permalink %}
+          {% if product.id != current_id %}
+            {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+            {% unless product_permalinks_array contains product_permalink %}
+              {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+            {% endunless %}
+          {% endif %}
+        {% endfor %}
+      {% endpaginate %}
+    {% endif %}
+    
+    {% comment %}
+    Step 3: Render Final Products
+    {% endcomment %}
+    {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
+    {% if final_permalinks_array.size > 0 %}
+      <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="Related products">
+        <h2 class="related-products-title">{{ theme.related_products_header }}</h2>
+        <div class="product-list-container">
+          <div class="related-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}">
+            {% for product_permalink in final_permalinks_array %}
+              {% assign matched_product = products[product_permalink] %}
+              {% assign matched_product_status = '' %}
+              {% case matched_product.status %} 
+                {% when 'active' %} 
+                  {% if matched_product.on_sale %}{% assign matched_product_status = 'On sale' %}{% endif %} 
+                {% when 'sold-out' %} 
+                  {% assign matched_product_status = 'Sold out' %} 
+                {% when 'coming-soon' %} 
+                  {% assign matched_product_status = 'Coming soon' %} 
+              {% endcase %}
+              {% capture matched_product_status_classes %}{{ theme.product_badge_style }} {% if matched_product.status == 'active' and matched_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+              {% if matched_product != blank %}
+                {% assign image_width = matched_product.image.width | times: 1.0 %}
+                {% assign image_height = matched_product.image.height | times: 1.0 %}
+                {% assign aspect_ratio = image_width | divided_by: image_height %}
+                {% capture image_class %}
+                  {% if matched_product.image.height > matched_product.image.width %}
+                    image-tall
+                  {% elsif matched_product.image.height < matched_product.image.width %}
+                    image-wide
+                  {% else %}
+                    image-square
+                  {% endif %}
+                {% endcapture %}
+                <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
+                  <div class="prod-thumb-container">
+                    <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                      <img
+                        alt=""
+                        class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                        src="{{ matched_product.image | product_image_url | constrain: 20 }}"
+                        {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
+                        data-srcset="
+                          {{ matched_product.image | product_image_url | constrain: 200 }} 200w,
+                          {{ matched_product.image | product_image_url | constrain: 280 }} 280w,
+                          {{ matched_product.image | product_image_url | constrain: 350 }} 350w,
+                          {{ matched_product.image | product_image_url | constrain: 400 }} 400w,
+                          {{ matched_product.image | product_image_url | constrain: 500 }} 500w,
+                          {{ matched_product.image | product_image_url | constrain: 650 }} 650w,
+                          {{ matched_product.image | product_image_url | constrain: 800 }} 800w,
+                          {{ matched_product.image | product_image_url | constrain: 1000 }} 1000w,
+                          {{ matched_product.image | product_image_url | constrain: 1200 }} 1200w,
+                          {{ matched_product.image | product_image_url | constrain: 1300 }} 1300w
+                        "
+                        data-sizes="auto"
+                      >
+                      {% if matched_product_status != blank and theme.product_badge_style != 'inline' %}
+                        <div class="prod-thumb-status {{ matched_product_status_classes }}">{{ matched_product_status }}</div>
+                      {% endif %}
+                      {% if theme.show_quickview %}
+                        <div class="product-list-quickview-container">
+                          <div class="product-list-quickview-container-background"></div>
+                          <button class="button open-quickview" data-permalink="{{ matched_product.permalink }}" data-has-default="{{ matched_product.has_default_option }}" title="Quick view {{ matched_product.name | escape }}" tabindex="-1">
+                            <span class="open-quickview-text">Quick View</span>
+                            <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
+                          </button>
+                        </div>
+                      {% endif %}
+                    </div>
+                  </div>
+                  <div class="prod-thumb-info">
+                    <div class="prod-thumb-background"></div>
+                    <div class="prod-thumb-info-headers">
+                      <div class="prod-thumb-name">{{ matched_product.name }}</div>
+                      <div class="prod-thumb-price">
+                        {% unless matched_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                          {% if matched_product.variable_pricing %}
+                            {{ matched_product.min_price | money: theme.money_format }} - {{ matched_product.max_price | money: theme.money_format }}
+                          {% else %}
+                            {{ matched_product.default_price | money: theme.money_format }}
+                          {% endif %}
+                        {% endunless %}
+                      </div>
+                      {% if matched_product_status != blank and theme.product_badge_style == 'inline' %}
+                        <div class="prod-thumb-status {{ matched_product_status_classes }}">{{ matched_product_status }}</div>
+                      {% endif %}
+                      {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
+                        <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ matched_product.permalink }}" data-has-default="{{ matched_product.has_default_option }}" title="Quick view {{ matched_product.name | escape }}">
+                          <span class="open-quickview-text">Quick View</span>
+                          <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
+                        </div>
+                      {% endif %}
+                    </div>
+                  </div>
+                </a>
+              {% endif %}
+            {% endfor %}
+          </div>
+        </div>
+      </aside>
+    {% endif %}
   {% endif %}
-{% endif %}
-{% if product_divs != blank %}
-  <aside class="related-products-container" data-num-products="{{ theme.number_related_products }}" role="complementary" aria-label="Related products">
-    <div class="all-similar-products" style="display: none">{{ product_divs }}</div>
-    <h2 class="similar-products-title">Related products</h2>
-    <div class="product-list-container">
-      <div class="similar-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}"></div>
-    </div>
-  </aside>
 {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -196,6 +196,7 @@
             </div>
           </div>
           {{ store | instant_checkout_button: 'light', '50px' }}
+          <div class="inventory-status-message" data-inventory-message></div>
           {% if product.has_option_groups %}
             <div class="reset-selection-button-container">
               <button class="button min-btn reset-selection-button" type="reset">Reset selection</button>

--- a/source/product.html
+++ b/source/product.html
@@ -245,96 +245,98 @@
   {% assign related_products_header = theme.related_products_header | default: 'You might also like' %}
   {% assign related_products_collection = product.related_products %}
 
-  <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
-    <h2 class="related-products-title">{{ related_products_header }}</h2>
-    <div class="product-list-container">
-      <div class="related-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}">
-        {% for related_product in related_products_collection %}
-          {% assign related_product_status = '' %}
-          {% case related_product.status %} 
-            {% when 'active' %} 
-              {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %} 
-            {% when 'sold-out' %} 
-              {% assign related_product_status = 'Sold out' %} 
-            {% when 'coming-soon' %} 
-              {% assign related_product_status = 'Coming soon' %} 
-          {% endcase %}
-          {% capture related_product_status_classes %}{{ theme.product_badge_style }} {% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-          {% assign image_width = related_product.image.width | times: 1.0 %}
-          {% assign image_height = related_product.image.height | times: 1.0 %}
-          {% assign aspect_ratio = image_width | divided_by: image_height %}
-          {% capture image_class %}
-            {% if related_product.image.height > related_product.image.width %}
-              image-tall
-            {% elsif related_product.image.height < related_product.image.width %}
-              image-wide
-            {% else %}
-              image-square
-            {% endif %}
-          {% endcapture %}
-          <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
-            <div class="prod-thumb-container">
-              <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                <img
-                  alt=""
-                  class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                  src="{{ related_product.image | product_image_url | constrain: 20 }}"
-                  {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
-                  data-srcset="
-                    {{ related_product.image | product_image_url | constrain: 200 }} 200w,
-                    {{ related_product.image | product_image_url | constrain: 280 }} 280w,
-                    {{ related_product.image | product_image_url | constrain: 350 }} 350w,
-                    {{ related_product.image | product_image_url | constrain: 400 }} 400w,
-                    {{ related_product.image | product_image_url | constrain: 500 }} 500w,
-                    {{ related_product.image | product_image_url | constrain: 650 }} 650w,
-                    {{ related_product.image | product_image_url | constrain: 800 }} 800w,
-                    {{ related_product.image | product_image_url | constrain: 1000 }} 1000w,
-                    {{ related_product.image | product_image_url | constrain: 1200 }} 1200w,
-                    {{ related_product.image | product_image_url | constrain: 1300 }} 1300w
-                  "
-                  data-sizes="auto"
-                >
-                {% if related_product_status != blank and theme.product_badge_style != 'inline' %}
-                  <div class="prod-thumb-status {{ related_product_status_classes }}">{{ related_product_status }}</div>
-                {% endif %}
-                {% if theme.show_quickview %}
-                  <div class="product-list-quickview-container">
-                    <div class="product-list-quickview-container-background"></div>
-                    <button class="button open-quickview" data-permalink="{{ related_product.permalink }}" data-has-default="{{ related_product.has_default_option }}" title="Quick view {{ related_product.name | escape }}" tabindex="-1">
+  {% if related_products_collection.size > 0 %}
+    <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
+      <h2 class="related-products-title">{{ related_products_header }}</h2>
+      <div class="product-list-container">
+        <div class="related-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}">
+          {% for related_product in related_products_collection %}
+            {% assign related_product_status = '' %}
+            {% case related_product.status %} 
+              {% when 'active' %} 
+                {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %} 
+              {% when 'sold-out' %} 
+                {% assign related_product_status = 'Sold out' %} 
+              {% when 'coming-soon' %} 
+                {% assign related_product_status = 'Coming soon' %} 
+            {% endcase %}
+            {% capture related_product_status_classes %}{{ theme.product_badge_style }} {% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+            {% assign image_width = related_product.image.width | times: 1.0 %}
+            {% assign image_height = related_product.image.height | times: 1.0 %}
+            {% assign aspect_ratio = image_width | divided_by: image_height %}
+            {% capture image_class %}
+              {% if related_product.image.height > related_product.image.width %}
+                image-tall
+              {% elsif related_product.image.height < related_product.image.width %}
+                image-wide
+              {% else %}
+                image-square
+              {% endif %}
+            {% endcapture %}
+            <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+              <div class="prod-thumb-container">
+                <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                  <img
+                    alt=""
+                    class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                    src="{{ related_product.image | product_image_url | constrain: 20 }}"
+                    {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
+                    data-srcset="
+                      {{ related_product.image | product_image_url | constrain: 200 }} 200w,
+                      {{ related_product.image | product_image_url | constrain: 280 }} 280w,
+                      {{ related_product.image | product_image_url | constrain: 350 }} 350w,
+                      {{ related_product.image | product_image_url | constrain: 400 }} 400w,
+                      {{ related_product.image | product_image_url | constrain: 500 }} 500w,
+                      {{ related_product.image | product_image_url | constrain: 650 }} 650w,
+                      {{ related_product.image | product_image_url | constrain: 800 }} 800w,
+                      {{ related_product.image | product_image_url | constrain: 1000 }} 1000w,
+                      {{ related_product.image | product_image_url | constrain: 1200 }} 1200w,
+                      {{ related_product.image | product_image_url | constrain: 1300 }} 1300w
+                    "
+                    data-sizes="auto"
+                  >
+                  {% if related_product_status != blank and theme.product_badge_style != 'inline' %}
+                    <div class="prod-thumb-status {{ related_product_status_classes }}">{{ related_product_status }}</div>
+                  {% endif %}
+                  {% if theme.show_quickview %}
+                    <div class="product-list-quickview-container">
+                      <div class="product-list-quickview-container-background"></div>
+                      <button class="button open-quickview" data-permalink="{{ related_product.permalink }}" data-has-default="{{ related_product.has_default_option }}" title="Quick view {{ related_product.name | escape }}" tabindex="-1">
+                        <span class="open-quickview-text">Quick View</span>
+                        <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
+                      </button>
+                    </div>
+                  {% endif %}
+                </div>
+              </div>
+              <div class="prod-thumb-info">
+                <div class="prod-thumb-background"></div>
+                <div class="prod-thumb-info-headers">
+                  <div class="prod-thumb-name">{{ related_product.name }}</div>
+                  <div class="prod-thumb-price">
+                    {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% if related_product.variable_pricing %}
+                        {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
+                      {% else %}
+                        {{ related_product.default_price | money: theme.money_format }}
+                      {% endif %}
+                    {% endunless %}
+                  </div>
+                  {% if related_product_status != blank and theme.product_badge_style == 'inline' %}
+                    <div class="prod-thumb-status {{ related_product_status_classes }}">{{ related_product_status }}</div>
+                  {% endif %}
+                  {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
+                    <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ related_product.permalink }}" data-has-default="{{ related_product.has_default_option }}" title="Quick view {{ related_product.name | escape }}">
                       <span class="open-quickview-text">Quick View</span>
                       <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
-                    </button>
-                  </div>
-                {% endif %}
-              </div>
-            </div>
-            <div class="prod-thumb-info">
-              <div class="prod-thumb-background"></div>
-              <div class="prod-thumb-info-headers">
-                <div class="prod-thumb-name">{{ related_product.name }}</div>
-                <div class="prod-thumb-price">
-                  {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                    {% if related_product.variable_pricing %}
-                      {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
-                    {% else %}
-                      {{ related_product.default_price | money: theme.money_format }}
-                    {% endif %}
-                  {% endunless %}
+                    </div>
+                  {% endif %}
                 </div>
-                {% if related_product_status != blank and theme.product_badge_style == 'inline' %}
-                  <div class="prod-thumb-status {{ related_product_status_classes }}">{{ related_product_status }}</div>
-                {% endif %}
-                {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
-                  <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ related_product.permalink }}" data-has-default="{{ related_product.has_default_option }}" title="Quick view {{ related_product.name | escape }}">
-                    <span class="open-quickview-text">Quick View</span>
-                    <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
-                  </div>
-                {% endif %}
               </div>
-            </div>
-          </a>
-        {% endfor %}
+            </a>
+          {% endfor %}
+        </div>
       </div>
-    </div>
-  </aside>
+    </aside>
+  {% endif %}
 {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -293,8 +293,8 @@
     {% endcomment %}
     {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
     {% if final_permalinks_array.size > 0 %}
-      <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="Related products">
-        <h2 class="related-products-title">{{ theme.related_products_header }}</h2>
+      <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.related_products_header | default: 'You might also like' }}">
+        <h2 class="related-products-title">{{ theme.related_products_header | default: 'You might also like' }}</h2>
         <div class="product-list-container">
           <div class="related-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}">
             {% for product_permalink in final_permalinks_array %}

--- a/source/product.html
+++ b/source/product.html
@@ -252,17 +252,22 @@
     {% endcomment %}
     {% if product.categories != blank %}
       {% for category in product.categories limit: 4 %}
+        {% if current_count >= related_products_limit %}
+          {% break %}
+        {% endif %}
+        
         {% for product in category.products | order: theme.related_products_order %}
-          {% if final_product_permalinks | split: ',' | size < related_products_limit %}
-            {% assign product_permalink = product.permalink %}
-            {% if product.id != current_id %}
-              {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-              {% unless product_permalinks_array contains product_permalink %}
-                {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-              {% endunless %}
-            {% endif %}
-          {% else %}
+          {% if current_count >= related_products_limit %}
             {% break %}
+          {% endif %}
+          
+          {% assign product_permalink = product.permalink %}
+          {% if product.id != current_id %}
+            {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
+            {% unless product_permalinks_array contains product_permalink %}
+              {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
+              {% assign current_count = current_count | plus: 1 %}
+            {% endunless %}
           {% endif %}
         {% endfor %}
       {% endfor %}

--- a/source/product.html
+++ b/source/product.html
@@ -241,158 +241,100 @@
     {% endif %}
   </div>
 </div>
-{% if page.full_url contains '/product/' %}
-  {% if theme.show_related_products %}
-    {% assign current_id = product.id | to_string %}
-    {% assign related_products_limit = theme.number_related_products | default: 4 %}
-    {% assign final_product_permalinks = '' %}
-    
-    {% comment %}
-    Step 1: Collect Products from Categories
-    {% endcomment %}
-    {% if product.categories != blank %}
-      {% for category in product.categories limit: 4 %}
-        {% if current_count >= related_products_limit %}
-          {% break %}
-        {% endif %}
-        
-        {% for product in category.products | order: theme.related_products_order %}
-          {% if current_count >= related_products_limit %}
-            {% break %}
-          {% endif %}
-          
-          {% assign product_permalink = product.permalink %}
-          {% if product.id != current_id %}
-            {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-            {% unless product_permalinks_array contains product_permalink %}
-              {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-              {% assign current_count = current_count | plus: 1 %}
-            {% endunless %}
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
-    {% endif %}
-    
-    {% comment %}
-    Step 2: Collect Fallback Products from products.all
-    {% endcomment %}
-    {% assign current_count = final_product_permalinks | split: ',' | size %}
-    {% assign remaining_limit = related_products_limit | minus: current_count %}
-    
-    {% if remaining_limit > 0 %}
-      {% paginate products from products.all by remaining_limit order: theme.related_products_order %}
-        {% for product in products %}
-          {% assign product_permalink = product.permalink %}
-          {% if product.id != current_id %}
-            {% assign product_permalinks_array = final_product_permalinks | split: ',' %}
-            {% unless product_permalinks_array contains product_permalink %}
-              {% assign final_product_permalinks = final_product_permalinks | append: product_permalink | append: ',' %}
-            {% endunless %}
-          {% endif %}
-        {% endfor %}
-      {% endpaginate %}
-    {% endif %}
-    
-    {% comment %}
-    Step 3: Render Final Products
-    {% endcomment %}
-    {% assign final_permalinks_array = final_product_permalinks | split: ',' %}
-    {% if final_permalinks_array.size > 0 %}
-      <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.related_products_header | default: 'You might also like' }}">
-        <h2 class="related-products-title">{{ theme.related_products_header | default: 'You might also like' }}</h2>
-        <div class="product-list-container">
-          <div class="related-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}">
-            {% for product_permalink in final_permalinks_array %}
-              {% assign matched_product = products[product_permalink] %}
-              {% assign matched_product_status = '' %}
-              {% case matched_product.status %} 
-                {% when 'active' %} 
-                  {% if matched_product.on_sale %}{% assign matched_product_status = 'On sale' %}{% endif %} 
-                {% when 'sold-out' %} 
-                  {% assign matched_product_status = 'Sold out' %} 
-                {% when 'coming-soon' %} 
-                  {% assign matched_product_status = 'Coming soon' %} 
-              {% endcase %}
-              {% capture matched_product_status_classes %}{{ theme.product_badge_style }} {% if matched_product.status == 'active' and matched_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-              {% if matched_product != blank %}
-                {% assign image_width = matched_product.image.width | times: 1.0 %}
-                {% assign image_height = matched_product.image.height | times: 1.0 %}
-                {% assign aspect_ratio = image_width | divided_by: image_height %}
-                {% capture image_class %}
-                  {% if matched_product.image.height > matched_product.image.width %}
-                    image-tall
-                  {% elsif matched_product.image.height < matched_product.image.width %}
-                    image-wide
-                  {% else %}
-                    image-square
-                  {% endif %}
-                {% endcapture %}
-                <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ matched_product.url }}" title="View {{ matched_product.name | escape }}">
-                  <div class="prod-thumb-container">
-                    <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
-                      <img
-                        alt=""
-                        class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
-                        src="{{ matched_product.image | product_image_url | constrain: 20 }}"
-                        {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
-                        data-srcset="
-                          {{ matched_product.image | product_image_url | constrain: 200 }} 200w,
-                          {{ matched_product.image | product_image_url | constrain: 280 }} 280w,
-                          {{ matched_product.image | product_image_url | constrain: 350 }} 350w,
-                          {{ matched_product.image | product_image_url | constrain: 400 }} 400w,
-                          {{ matched_product.image | product_image_url | constrain: 500 }} 500w,
-                          {{ matched_product.image | product_image_url | constrain: 650 }} 650w,
-                          {{ matched_product.image | product_image_url | constrain: 800 }} 800w,
-                          {{ matched_product.image | product_image_url | constrain: 1000 }} 1000w,
-                          {{ matched_product.image | product_image_url | constrain: 1200 }} 1200w,
-                          {{ matched_product.image | product_image_url | constrain: 1300 }} 1300w
-                        "
-                        data-sizes="auto"
-                      >
-                      {% if matched_product_status != blank and theme.product_badge_style != 'inline' %}
-                        <div class="prod-thumb-status {{ matched_product_status_classes }}">{{ matched_product_status }}</div>
-                      {% endif %}
-                      {% if theme.show_quickview %}
-                        <div class="product-list-quickview-container">
-                          <div class="product-list-quickview-container-background"></div>
-                          <button class="button open-quickview" data-permalink="{{ matched_product.permalink }}" data-has-default="{{ matched_product.has_default_option }}" title="Quick view {{ matched_product.name | escape }}" tabindex="-1">
-                            <span class="open-quickview-text">Quick View</span>
-                            <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
-                          </button>
-                        </div>
-                      {% endif %}
-                    </div>
+{% if theme.show_related_products %}
+  {% assign related_products_header = theme.related_products_header | default: 'You might also like' %}
+  {% assign related_products_collection = product.related_products %}
+
+  <aside class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
+    <h2 class="related-products-title">{{ related_products_header }}</h2>
+    <div class="product-list-container">
+      <div class="related-product-list product-list {{ theme.product_list_layout }} mobile-{{ theme.mobile_product_grid_style }} grid-{{ theme.layout_style }}">
+        {% for related_product in related_products_collection %}
+          {% assign related_product_status = '' %}
+          {% case related_product.status %} 
+            {% when 'active' %} 
+              {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %} 
+            {% when 'sold-out' %} 
+              {% assign related_product_status = 'Sold out' %} 
+            {% when 'coming-soon' %} 
+              {% assign related_product_status = 'Coming soon' %} 
+          {% endcase %}
+          {% capture related_product_status_classes %}{{ theme.product_badge_style }} {% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
+          {% assign image_width = related_product.image.width | times: 1.0 %}
+          {% assign image_height = related_product.image.height | times: 1.0 %}
+          {% assign aspect_ratio = image_width | divided_by: image_height %}
+          {% capture image_class %}
+            {% if related_product.image.height > related_product.image.width %}
+              image-tall
+            {% elsif related_product.image.height < related_product.image.width %}
+              image-wide
+            {% else %}
+              image-square
+            {% endif %}
+          {% endcapture %}
+          <a class="prod-thumb product-image-{{ theme.product_grid_image_size }} {{ theme.show_overlay }} {{ theme.grid_image_style }} {% if theme.show_quickview %}show-quickview{% endif %}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+            <div class="prod-thumb-container">
+              <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
+                <img
+                  alt=""
+                  class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                  src="{{ related_product.image | product_image_url | constrain: 20 }}"
+                  {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
+                  data-srcset="
+                    {{ related_product.image | product_image_url | constrain: 200 }} 200w,
+                    {{ related_product.image | product_image_url | constrain: 280 }} 280w,
+                    {{ related_product.image | product_image_url | constrain: 350 }} 350w,
+                    {{ related_product.image | product_image_url | constrain: 400 }} 400w,
+                    {{ related_product.image | product_image_url | constrain: 500 }} 500w,
+                    {{ related_product.image | product_image_url | constrain: 650 }} 650w,
+                    {{ related_product.image | product_image_url | constrain: 800 }} 800w,
+                    {{ related_product.image | product_image_url | constrain: 1000 }} 1000w,
+                    {{ related_product.image | product_image_url | constrain: 1200 }} 1200w,
+                    {{ related_product.image | product_image_url | constrain: 1300 }} 1300w
+                  "
+                  data-sizes="auto"
+                >
+                {% if related_product_status != blank and theme.product_badge_style != 'inline' %}
+                  <div class="prod-thumb-status {{ related_product_status_classes }}">{{ related_product_status }}</div>
+                {% endif %}
+                {% if theme.show_quickview %}
+                  <div class="product-list-quickview-container">
+                    <div class="product-list-quickview-container-background"></div>
+                    <button class="button open-quickview" data-permalink="{{ related_product.permalink }}" data-has-default="{{ related_product.has_default_option }}" title="Quick view {{ related_product.name | escape }}" tabindex="-1">
+                      <span class="open-quickview-text">Quick View</span>
+                      <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
+                    </button>
                   </div>
-                  <div class="prod-thumb-info">
-                    <div class="prod-thumb-background"></div>
-                    <div class="prod-thumb-info-headers">
-                      <div class="prod-thumb-name">{{ matched_product.name }}</div>
-                      <div class="prod-thumb-price">
-                        {% unless matched_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-                          {% if matched_product.variable_pricing %}
-                            {{ matched_product.min_price | money: theme.money_format }} - {{ matched_product.max_price | money: theme.money_format }}
-                          {% else %}
-                            {{ matched_product.default_price | money: theme.money_format }}
-                          {% endif %}
-                        {% endunless %}
-                      </div>
-                      {% if matched_product_status != blank and theme.product_badge_style == 'inline' %}
-                        <div class="prod-thumb-status {{ matched_product_status_classes }}">{{ matched_product_status }}</div>
-                      {% endif %}
-                      {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
-                        <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ matched_product.permalink }}" data-has-default="{{ matched_product.has_default_option }}" title="Quick view {{ matched_product.name | escape }}">
-                          <span class="open-quickview-text">Quick View</span>
-                          <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
-                        </div>
-                      {% endif %}
-                    </div>
+                {% endif %}
+              </div>
+            </div>
+            <div class="prod-thumb-info">
+              <div class="prod-thumb-background"></div>
+              <div class="prod-thumb-info-headers">
+                <div class="prod-thumb-name">{{ related_product.name }}</div>
+                <div class="prod-thumb-price">
+                  {% unless related_product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% if related_product.variable_pricing %}
+                      {{ related_product.min_price | money: theme.money_format }} - {{ related_product.max_price | money: theme.money_format }}
+                    {% else %}
+                      {{ related_product.default_price | money: theme.money_format }}
+                    {% endif %}
+                  {% endunless %}
+                </div>
+                {% if related_product_status != blank and theme.product_badge_style == 'inline' %}
+                  <div class="prod-thumb-status {{ related_product_status_classes }}">{{ related_product_status }}</div>
+                {% endif %}
+                {% if theme.show_quickview and theme.mobile_product_grid_style == 'horizontal' %}
+                  <div role="button" class="button open-quickview mobile-stacked-quickview" data-permalink="{{ related_product.permalink }}" data-has-default="{{ related_product.has_default_option }}" title="Quick view {{ related_product.name | escape }}">
+                    <span class="open-quickview-text">Quick View</span>
+                    <svg aria-hidden="true" class="open-quickview-icon" width="19" height="12" viewBox="0 0 19 12" xmlns="http://www.w3.org/2000/svg"><path d="M9.16664521 12c3.84154359 0 7.19749259-2.23873368 8.89121419-5.54405416.0600279-.1187131.1087338-.32305832.1087338-.45608412 0-.13302581-.0487059-.33737102-.1087338-.45608412C16.3631918 2.23720589 13.0081888.00002861 9.16664521.00002861c-3.84154358 0-7.19749261 2.23873368-8.89121415 5.54405416-.06002794.1187131-.10873388.32305832-.10873388.45608412 0 .13302581.04870594.33737102.10873388.45608412C1.97009865 9.76282272 5.32510163 12 9.1666452 12zm.00219726-1.4999964h-.00219726c-2.48400287 0-4.49998927-2.01598643-4.49998927-4.49998929 0-2.48400287 2.0159864-4.49998928 4.49998927-4.49998928 2.48400289 0 4.49998929 2.01598641 4.49998929 4.49998928v.00219726c0 2.48278216-2.0150099 4.49779203-4.49779203 4.49779203zm.00485228-1.51375984c1.65218725 0 2.99312645-1.34090867 2.99312645-2.99312641 0-1.65218722-1.3409392-2.99309589-2.99312645-2.99309589h-.00704954c-.22271676.00311278-.57705551.05618273-.79092219.11843844.16058312.21823068.29092338.61529394.29092338.88625887 0 .82540697-.66988976 1.49530269-1.49529673 1.49530269-.27096493 0-.66802819-.13034623-.88625887-.29092934-.0577086.21255442-.10452246.56378039-.10452246.78402523 0 1.65221774 1.34090867 2.99312641 2.99312641 2.99312641z" fill-rule="nonzero"/></svg>
                   </div>
-                </a>
-              {% endif %}
-            {% endfor %}
-          </div>
-        </div>
-      </aside>
-    {% endif %}
-  {% endif %}
+                {% endif %}
+              </div>
+            </div>
+          </a>
+        {% endfor %}
+      </div>
+    </div>
+  </aside>
 {% endif %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -47,6 +47,7 @@
               "badge_background_color_primary": "#9AFF00",
               "badge_text_color_secondary": "#000000",
               "badge_background_color_secondary": "#E0E0E0",
+              "inventory_status_text_color": "#056FFA",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -69,6 +70,7 @@
               "badge_background_color_primary": "#141415",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#F8F8F8",
               "announcement_text_color": "#F8F8F8",
               "announcement_background_color": "#4D4D4D"
             }
@@ -91,6 +93,7 @@
               "badge_background_color_primary": "#203BE1",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#203BE1",
               "announcement_text_color": "#0C143B",
               "announcement_background_color": "#E3E4EA"
             }
@@ -118,6 +121,7 @@
               "badge_background_color_primary": "#898952",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#8A4942",
               "announcement_text_color": "#262522",
               "announcement_background_color": "#F1DBCE"
             }
@@ -140,6 +144,7 @@
               "badge_background_color_primary": "#78A9F9",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#E86054",
               "announcement_text_color": "#1F161B",
               "announcement_background_color": "#D6E3F8"
             }
@@ -167,6 +172,7 @@
               "badge_background_color_primary": "#0000FF",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#0000FF",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -189,6 +195,7 @@
               "badge_background_color_primary": "#22FFF8",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#F90081",
               "announcement_text_color": "#0B0423",
               "announcement_background_color": "#F6FF20"
             }
@@ -211,6 +218,7 @@
               "badge_background_color_primary": "#9AFF00",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#056FFA",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -233,6 +241,7 @@
               "badge_background_color_primary": "#FFFA8D",
               "badge_text_color_secondary": "#141415",
               "badge_background_color_secondary": "#D8D8D8",
+              "inventory_status_text_color": "#243588",
               "announcement_text_color": "#0C143B",
               "announcement_background_color": "#FFFA8D"
             }
@@ -308,6 +317,11 @@
       "variable": "badge_background_color_secondary",
       "label": "Badge background (secondary)",
       "default": "#E0E0E0"
+    },
+    {
+      "variable": "inventory_status_text_color",
+      "label": "Low Inventory messages",
+      "default": "#056FFA"
     },
     {
       "variable": "announcement_text_color",
@@ -633,6 +647,57 @@
       "default": false,
       "description": "Shows a product's inventory amounts (when using inventory tracking)",
       "requires": ["inventory"]
+    },
+    {
+      "variable": "show_low_inventory_messages",
+      "label": "Show product stock alerts",
+      "type": "boolean",
+      "default": true,
+      "description": "Show shoppers alerts on Product pages when it's running low on stock",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false"
+      ]
+    },
+    {
+      "variable": "low_inventory_threshold",
+      "label": "Low stock alert",
+      "options": "1..100",
+      "type": "select",
+      "default": "10",
+      "description": "When stock drops below this number, shoppers will see low stock message. 'Almost sold out' message shows at half this amount",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false",
+        "show_low_inventory_messages eq true"
+      ]
+    },
+    {
+      "variable": "low_inventory_message",
+      "label": "Low stock message",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below your alert level",
+      "default": "Limited quantities available",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false",
+        "show_low_inventory_messages eq true"
+      ]
+    },
+    {
+      "variable": "almost_sold_out_message",
+      "label": "Almost sold out message",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below half your alert level",
+      "default": "Only a few left!",
+      "requires": [
+        "inventory",
+        "show_inventory_bars eq false",
+        "show_low_inventory_messages eq true",
+        "low_inventory_threshold gt 1"
+      ]
     },
     {
       "variable": "footer_text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -554,12 +554,44 @@
       "description": "The number of products shown per page"
     },
     {
+      "variable": "show_related_products",
+      "label": "Show related products",
+      "type": "boolean",
+      "default": true,
+      "description": "Display recommended products on Product pages starting with same category"
+    },
+    {
       "variable": "number_related_products",
       "label": "Number of related products",
       "type": "select",
-      "options": "0..6",
+      "options": "1..8",
       "default": 3,
-      "description": "The number of related products to show on the Product page"
+      "description": "The number of related products to show on the Product page",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "related_products_header",
+      "label": "Related products header",
+      "type": "text",
+      "max_length": 75,
+      "description": "Displays above related products on Products pages",
+      "default": "You might also like",
+      "requires": [
+        "show_related_products eq true"
+      ]
+    },
+    {
+      "variable": "related_products_order",
+      "label": "Related products order",
+      "type": "select",
+      "options": "product_orders",
+      "default": "sales",
+      "description": "The order of related products on the Product pages",
+      "requires": [
+        "show_related_products eq true"
+      ]
     },
     {
       "variable": "show_quickview",

--- a/source/settings.json
+++ b/source/settings.json
@@ -663,6 +663,18 @@
       "description": "Ex: https://youtube.com/@BigCartelDotCom"
     },
     {
+      "variable": "spotify_url",
+      "label": "Spotify URL",
+      "type": "text",
+      "description": "Ex: https://open.spotify.com/artist/0gxy..."
+    },
+    {
+      "variable": "linkedin_url",
+      "label": "LinkedIn URL",
+      "type": "text",
+      "description": "Ex: https://linkedin.com/in/bigcartel"
+    },
+    {
       "variable": "tumblr_url",
       "label": "Tumblr URL",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -597,7 +597,7 @@
       "variable": "show_quickview",
       "label": "Show quick view",
       "type": "boolean",
-      "default": true,
+      "default": false,
       "description": "Enables quick view & buttons on product thumbnails"
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -55,98 +55,121 @@
           {
             "style_name": "Classic #2",
             "fonts": {
-              "primary_font": "DM Sans"
+              "primary_font": "Crimson Text"
             },
             "colors": {
-              "background_color": "#141415",
-              "primary_text_color": "#F8F8F8",
-              "link_hover_color": "#AEAEAE",
-              "border_color": "#4D4D4D",
-              "button_text_color": "#141415",
-              "button_background_color": "#F8F8F8",
-              "button_hover_text_color": "#F8F8F8",
-              "button_hover_background_color": "#4D4D4D",
-              "badge_text_color_primary": "#F8F8F8",
-              "badge_background_color_primary": "#141415",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#F8F8F8",
-              "announcement_text_color": "#F8F8F8",
-              "announcement_background_color": "#4D4D4D"
+              "background_color": "#2D364C",
+              "primary_text_color": "#FFFFFF",
+              "link_hover_color": "#93C5FD",
+              "border_color": "#3D4A66",
+              "button_text_color": "#2D364C",
+              "button_background_color": "#FFFFFF",
+              "button_hover_text_color": "#2D364C",
+              "button_hover_background_color": "#93C5FD",
+              "badge_text_color_primary": "#2D364C",
+              "badge_background_color_primary": "#93C5FD",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#3D4A66",
+              "inventory_status_text_color": "#93C5FD",
+              "announcement_text_color": "#2D364C",
+              "announcement_background_color": "#FFFFFF"
             }
           },
           {
             "style_name": "Classic #3",
             "fonts": {
-              "primary_font": "DM Sans"
+              "primary_font": "Lora"
             },
             "colors": {
-              "background_color": "#F8F8FA",
-              "primary_text_color": "#2A2A2C",
-              "link_hover_color": "#203BE1",
-              "border_color": "#E3E4EA",
-              "button_text_color": "#F8F8FA",
-              "button_background_color": "#203BE1",
-              "button_hover_text_color": "#F8F8F8",
-              "button_hover_background_color": "#2A2A2C",
-              "badge_text_color_primary": "#F8F8FA",
-              "badge_background_color_primary": "#203BE1",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#203BE1",
-              "announcement_text_color": "#0C143B",
-              "announcement_background_color": "#E3E4EA"
+              "background_color": "#F8F9FA",
+              "primary_text_color": "#2C3E50",
+              "link_hover_color": "#7B341E",
+              "border_color": "#E2E8F0",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#2C3E50",
+              "button_hover_text_color": "#FFFFFF",
+              "button_hover_background_color": "#7B341E",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#7B341E",
+              "badge_text_color_secondary": "#2C3E50",
+              "badge_background_color_secondary": "#E2E8F0",
+              "inventory_status_text_color": "#7B341E",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#2C3E50"
             }
           }
         ]
       },
       {
-        "group_name": "Natural",
+        "group_name": "Bold",
         "styles": [
           {
-            "style_name": "Natural #1",
+            "style_name": "Bold #1",
             "fonts": {
-              "primary_font": "Lato"
+              "primary_font": "Space Grotesk"
             },
             "colors": {
-              "background_color": "#F5F4EE",
-              "primary_text_color": "#262522",
-              "link_hover_color": "#8A4942",
-              "border_color": "#E1DECC",
-              "button_text_color": "#F5F4EE",
-              "button_background_color": "#8A4942",
-              "button_hover_text_color": "#F5F4EE",
-              "button_hover_background_color": "#262522",
-              "badge_text_color_primary": "#F5F4EE",
-              "badge_background_color_primary": "#898952",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#8A4942",
-              "announcement_text_color": "#262522",
-              "announcement_background_color": "#F1DBCE"
+              "background_color": "#000000",
+              "primary_text_color": "#FFFFFF",
+              "link_hover_color": "#FF3D00",
+              "border_color": "#333333",
+              "button_text_color": "#000000",
+              "button_background_color": "#FF3D00",
+              "button_hover_text_color": "#000000",
+              "button_hover_background_color": "#FF6E40",
+              "badge_text_color_primary": "#000000",
+              "badge_background_color_primary": "#FF3D00",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#333333",
+              "inventory_status_text_color": "#FF3D00",
+              "announcement_text_color": "#000000",
+              "announcement_background_color": "#FF3D00"
             }
           },
           {
-            "style_name": "Natural #2",
+            "style_name": "Bold #2",
             "fonts": {
-              "primary_font": "Cutive Mono"
+              "primary_font": "Oswald"
             },
             "colors": {
-              "background_color": "#FEF5EF",
-              "primary_text_color": "#584B53",
-              "link_hover_color": "#1F161B",
-              "border_color": "#FADBC6",
-              "button_text_color": "#FEF5EF",
-              "button_background_color": "#584B53",
-              "button_hover_text_color": "#FEF5EF",
-              "button_hover_background_color": "#1F161B",
-              "badge_text_color_primary": "#1F161B",
-              "badge_background_color_primary": "#78A9F9",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#E86054",
-              "announcement_text_color": "#1F161B",
-              "announcement_background_color": "#D6E3F8"
+              "background_color": "#8C1BAB",
+              "primary_text_color": "#FFFFFF",
+              "link_hover_color": "#FFE03D",
+              "border_color": "#A346C4",
+              "button_text_color": "#8C1BAB",
+              "button_background_color": "#FFE03D",
+              "button_hover_text_color": "#8C1BAB",
+              "button_hover_background_color": "#FFF066",
+              "badge_text_color_primary": "#8C1BAB",
+              "badge_background_color_primary": "#FFE03D",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#A346C4",
+              "inventory_status_text_color": "#FFE03D",
+              "announcement_text_color": "#8C1BAB",
+              "announcement_background_color": "#FFE03D"
+            }
+          },
+          {
+            "style_name": "Bold #3",
+            "fonts": {
+              "primary_font": "Syne"
+            },
+            "colors": {
+              "background_color": "#FFFFFF",
+              "primary_text_color": "#000000",
+              "link_hover_color": "#FF0066",
+              "border_color": "#000000",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#000000",
+              "button_hover_text_color": "#FFFFFF",
+              "button_hover_background_color": "#FF0066",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#FF0066",
+              "badge_text_color_secondary": "#000000",
+              "badge_background_color_secondary": "#E0E0E0",
+              "inventory_status_text_color": "#FF0066",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#000000"
             }
           }
         ]
@@ -157,93 +180,218 @@
           {
             "style_name": "Playful #1",
             "fonts": {
-              "primary_font": "Syne"
+              "primary_font": "Fredoka One"
             },
             "colors": {
-              "background_color": "#CEFF66",
-              "primary_text_color": "#000000",
-              "link_hover_color": "#0000FF",
-              "border_color": "#000000",
-              "button_text_color": "#FFFFFF",
-              "button_background_color": "#0000FF",
-              "button_hover_text_color": "#FFFFFF",
-              "button_hover_background_color": "#000000",
-              "badge_text_color_primary": "#FFFFFF",
-              "badge_background_color_primary": "#0000FF",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#0000FF",
-              "announcement_text_color": "#FFFFFF",
-              "announcement_background_color": "#000000"
+              "background_color": "#FF647C",
+              "primary_text_color": "#FFFFFF",
+              "link_hover_color": "#00E6C3",
+              "border_color": "#FF89AC",
+              "button_text_color": "#FF647C",
+              "button_background_color": "#00E6C3",
+              "button_hover_text_color": "#FF647C",
+              "button_hover_background_color": "#33FFDA",
+              "badge_text_color_primary": "#FF647C",
+              "badge_background_color_primary": "#00E6C3",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#FF89AC",
+              "inventory_status_text_color": "#00E6C3",
+              "announcement_text_color": "#FF647C",
+              "announcement_background_color": "#00E6C3"
             }
           },
           {
             "style_name": "Playful #2",
             "fonts": {
-              "primary_font": "Concert One"
+              "primary_font": "Quicksand"
             },
             "colors": {
-              "background_color": "#FFFFFF",
-              "primary_text_color": "#0B0423",
-              "link_hover_color": "#F90081",
-              "border_color": "#EDEFEF",
-              "button_text_color": "#FFFFFF",
-              "button_background_color": "#F90081",
-              "button_hover_text_color": "#FFFFFF",
-              "button_hover_background_color": "#D1006C",
-              "badge_text_color_primary": "#0B0423",
-              "badge_background_color_primary": "#22FFF8",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#F90081",
-              "announcement_text_color": "#0B0423",
-              "announcement_background_color": "#F6FF20"
+              "background_color": "#1139FF",
+              "primary_text_color": "#FFFFFF",
+              "link_hover_color": "#FFE81A",
+              "border_color": "#4D69FF",
+              "button_text_color": "#1139FF",
+              "button_background_color": "#FFE81A",
+              "button_hover_text_color": "#1139FF",
+              "button_hover_background_color": "#FFF066",
+              "badge_text_color_primary": "#1139FF",
+              "badge_background_color_primary": "#FFE81A",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#4D69FF",
+              "inventory_status_text_color": "#FFE81A",
+              "announcement_text_color": "#1139FF",
+              "announcement_background_color": "#FFE81A"
             }
           },
           {
             "style_name": "Playful #3",
             "fonts": {
-              "primary_font": "Syne"
+              "primary_font": "Delius"
             },
             "colors": {
-              "background_color": "#FFFFFF",
-              "primary_text_color": "#000000",
-              "link_hover_color": "#056FFA",
-              "border_color": "#000000",
+              "background_color": "#00B066",
+              "primary_text_color": "#FFFFFF",
+              "link_hover_color": "#FFB8FF",
+              "border_color": "#00D87D",
+              "button_text_color": "#00B066",
+              "button_background_color": "#FFB8FF",
+              "button_hover_text_color": "#00B066",
+              "button_hover_background_color": "#FFA1FF",
+              "badge_text_color_primary": "#00B066",
+              "badge_background_color_primary": "#FFB8FF",
+              "badge_text_color_secondary": "#FFFFFF",
+              "badge_background_color_secondary": "#00D87D",
+              "inventory_status_text_color": "#FFB8FF",
+              "announcement_text_color": "#00B066",
+              "announcement_background_color": "#FFB8FF"
+            }
+          }
+        ]
+      },
+      {
+        "group_name": "Earthy",
+        "styles": [
+          {
+            "style_name": "Earthy #1",
+            "fonts": {
+              "primary_font": "Cormorant"
+            },
+            "colors": {
+              "background_color": "#F4EDE4",
+              "primary_text_color": "#3A2E27",
+              "link_hover_color": "#A35829",
+              "border_color": "#D5C5B5",
               "button_text_color": "#FFFFFF",
-              "button_background_color": "#000000",
+              "button_background_color": "#A35829",
               "button_hover_text_color": "#FFFFFF",
-              "button_hover_background_color": "#056FFA",
-              "badge_text_color_primary": "#000000",
-              "badge_background_color_primary": "#9AFF00",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#056FFA",
+              "button_hover_background_color": "#8B4513",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#A35829",
+              "badge_text_color_secondary": "#3A2E27",
+              "badge_background_color_secondary": "#E2D5C3",
+              "inventory_status_text_color": "#A35829",
               "announcement_text_color": "#FFFFFF",
-              "announcement_background_color": "#000000"
+              "announcement_background_color": "#A35829"
             }
           },
           {
-            "style_name": "Playful #4",
+            "style_name": "Earthy #2",
             "fonts": {
-              "primary_font": "Quicksand"
+              "primary_font": "Andada Pro"
             },
             "colors": {
-              "background_color": "#FFE9F4",
-              "primary_text_color": "#243588",
-              "link_hover_color": "#0C143B",
-              "border_color": "#FACAE2",
-              "button_text_color": "#FFE9F4",
-              "button_background_color": "#243588",
-              "button_hover_text_color": "#243588",
-              "button_hover_background_color": "#FFFA8D",
-              "badge_text_color_primary": "#0C143B",
-              "badge_background_color_primary": "#FFFA8D",
-              "badge_text_color_secondary": "#141415",
-              "badge_background_color_secondary": "#D8D8D8",
-              "inventory_status_text_color": "#243588",
-              "announcement_text_color": "#0C143B",
-              "announcement_background_color": "#FFFA8D"
+              "background_color": "#264536",
+              "primary_text_color": "#F1EBE4",
+              "link_hover_color": "#E5B95F",
+              "border_color": "#3D6B54",
+              "button_text_color": "#264536",
+              "button_background_color": "#E5B95F",
+              "button_hover_text_color": "#264536",
+              "button_hover_background_color": "#D4A63D",
+              "badge_text_color_primary": "#264536",
+              "badge_background_color_primary": "#E5B95F",
+              "badge_text_color_secondary": "#F1EBE4",
+              "badge_background_color_secondary": "#3D6B54",
+              "inventory_status_text_color": "#E5B95F",
+              "announcement_text_color": "#264536",
+              "announcement_background_color": "#E5B95F"
+            }
+          },
+          {
+            "style_name": "Earthy #3",
+            "fonts": {
+              "primary_font": "Enriqueta"
+            },
+            "colors": {
+              "background_color": "#FFFFFF",
+              "primary_text_color": "#644E3B",
+              "link_hover_color": "#C17754",
+              "border_color": "#E8DFD3",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#A65A45",
+              "button_hover_text_color": "#FFFFFF",
+              "button_hover_background_color": "#A65F3F",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#C17754",
+              "badge_text_color_secondary": "#644E3B",
+              "badge_background_color_secondary": "#E8DFD3",
+              "inventory_status_text_color": "#C17754",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#C17754"
+            }
+          }
+        ]
+      },
+      {
+        "group_name": "Dreamy",
+        "styles": [
+          {
+            "style_name": "Dreamy #1",
+            "fonts": {
+              "primary_font": "Playfair Display"
+            },
+            "colors": {
+              "background_color": "#F0F7FF",
+              "primary_text_color": "#4A5D7C",
+              "link_hover_color": "#93B5E5",
+              "border_color": "#DBE7F7",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#93B5E5",
+              "button_hover_text_color": "#FFFFFF",
+              "button_hover_background_color": "#7B92AA",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#6B8EC1",
+              "badge_text_color_secondary": "#4A5D7C",
+              "badge_background_color_secondary": "#E5EEF9",
+              "inventory_status_text_color": "#6B8EC1",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#93B5E5"
+            }
+          },
+          {
+            "style_name": "Dreamy #2",
+            "fonts": {
+              "primary_font": "Spectral"
+            },
+            "colors": {
+              "background_color": "#F6EFF5",
+              "primary_text_color": "#806B88",
+              "link_hover_color": "#B799B2",
+              "border_color": "#E4D6E3",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#B799B2",
+              "button_hover_text_color": "#FFFFFF",
+              "button_hover_background_color": "#9A7D94",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#C9A4C4",
+              "badge_text_color_secondary": "#806B88",
+              "badge_background_color_secondary": "#E4D6E3",
+              "inventory_status_text_color": "#C9A4C4",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#B799B2"
+            }
+          },
+          {
+            "style_name": "Dreamy #3",
+            "fonts": {
+              "primary_font": "Marcellus"
+            },
+            "colors": {
+              "background_color": "#E8F3F5",
+              "primary_text_color": "#537780",
+              "link_hover_color": "#7EA9B1",
+              "border_color": "#C5DDE2",
+              "button_text_color": "#FFFFFF",
+              "button_background_color": "#7EA9B1",
+              "button_hover_text_color": "#FFFFFF",
+              "button_hover_background_color": "#537780",
+              "badge_text_color_primary": "#FFFFFF",
+              "badge_background_color_primary": "#FF8E6E",
+              "badge_text_color_secondary": "#537780",
+              "badge_background_color_secondary": "#DCE9EC",
+              "inventory_status_text_color": "#FF8E6E",
+              "announcement_text_color": "#FFFFFF",
+              "announcement_background_color": "#7EA9B1"
             }
           }
         ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -325,12 +325,14 @@
       "variable": "announcement_message_text",
       "label": "Announcement text",
       "type": "text",
+      "max_length": 500,
       "description": "Displays an announcement message on the top of every page"
     },
     {
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
       "type": "text",
+      "max_length": 2048,
       "description": "A message visitors see when your shop is in Maintenance Mode",
       "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
@@ -687,7 +689,7 @@
       "description": "Ex: https://bigcartel.bandcamp.com"
     }
   ],
- "checkout": {
+  "checkout": {
     "optimize_legibility": "optimizeLegibility",
     "header_image_max_width": "400px",
     "header_image_max_height": "200px",

--- a/source/settings.json
+++ b/source/settings.json
@@ -677,6 +677,12 @@
       "description": "Ex: https://linkedin.com/in/bigcartel"
     },
     {
+      "variable": "twitch_url",
+      "label": "Twitch URL",
+      "type": "text",
+      "description": "Ex: https://twitch.tv/username"
+    },
+    {
       "variable": "tumblr_url",
       "label": "Tumblr URL",
       "type": "text",

--- a/source/settings.json
+++ b/source/settings.json
@@ -635,6 +635,13 @@
       "requires": ["inventory"]
     },
     {
+      "variable": "footer_text",
+      "label": "Footer text",
+      "type": "text",
+      "max_length": 2048,
+      "description": "Show a custom message to your shop's footer"
+    },
+    {
       "variable": "money_format",
       "label": "Price display",
       "type": "select",

--- a/source/settings.json
+++ b/source/settings.json
@@ -543,7 +543,10 @@
       "type": "select",
       "options": "product_orders",
       "default": "position",
-      "description": "The order of products on the Home page"
+      "description": "The order of products on the Home page",
+      "requires": [
+        "featured_items gt 0"
+      ]
     },
     {
       "variable": "products_per_page",
@@ -608,20 +611,12 @@
       "description": "Displays a search field in the layout"
     },
     {
-      "variable": "show_inventory_bars",
-      "label": "Show inventory bars",
-      "type": "boolean",
-      "default": false,
-      "description": "Shows a product's inventory amounts (when using inventory tracking)",
-      "requires": "inventory"
-    },
-    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
       "description": "Shows sold out product variants in the Product page dropdowns",
-      "requires": "inventory"
+      "requires": ["inventory"]
     },
     {
       "variable": "show_sold_out_product_prices",
@@ -629,7 +624,15 @@
       "type": "boolean",
       "default": true,
       "description": "Show the price of sold out products on product grids and product pages",
-      "requires": "inventory"
+      "requires": ["inventory"]
+    },
+    {
+      "variable": "show_inventory_bars",
+      "label": "Show inventory bars",
+      "type": "boolean",
+      "default": false,
+      "description": "Shows a product's inventory amounts (when using inventory tracking)",
+      "requires": ["inventory"]
     },
     {
       "variable": "money_format",

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -16,6 +16,7 @@ $badge-background-color-primary: #{"{{ theme.badge_background_color_primary }}"}
 $badge-text-color_secondary: #{"{{ theme.badge_text_color_secondary }}"}
 $badge-background-color-secondary: #{"{{ theme.badge_background_color_secondary }}"}
 
+$inventory-status-text-color: #{"{{ theme.inventory_status_text_color }}"}
 
 $button-hover-text-color: #{"{{ theme.button_hover_text_color }}"}
 $button-hover-background-color: #{"{{ theme.button_hover_background_color }}"}

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -103,7 +103,7 @@ body
 
   &.background-image-overlay-transparent_color_overlay
     background-color: $background-color
-    opacity: .9
+    opacity: 0.9
 
 .header-above
   border-bottom: $large-border

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -763,6 +763,7 @@ _:-ms-fullscreen, :root .content-wrapper
 
 .nav-section-credit
   border: none !important
+  padding-top: 30px
 
 .bigcartel-credit
   font-size: 14px
@@ -809,9 +810,22 @@ footer
   +flexbox
   +flex-shrink(0)
 
+  .footer-custom-content
+    padding: 20px 0
+
   .social-links
+    display: flex
+    flex-wrap: wrap
     gap: 10px
     +justify-content(center)
+    width: 100%
+    padding: 0 $base-padding
+
+    a
+      display: flex
+      align-items: center
+      justify-content: center
+
 
   .footer-nav
     +flexbox
@@ -822,6 +836,9 @@ footer
     border-top: $medium-border
     padding: $base-padding * 5 0
     width: 100%
+
+    .nav-section-credit
+      padding-top: 20px
 
     .has-sidebar &
       display: none

--- a/source/stylesheets/maintenance.sass
+++ b/source/stylesheets/maintenance.sass
@@ -38,12 +38,19 @@
 .maintenance-message
   +fluid-type(18px, 24px)
   line-height: 1.25em
-  margin-top: $base-padding
+  margin-top: $base-padding * 2
+  padding-top: $base-padding * 4
+
+  h1, h2
+    padding: $base-padding 0
 
 .maintenance-social-links
   border-top: $small-border
-  margin-top: $base-padding
-  padding-top: $base-padding
+  margin-top: $base-padding * 4
+  padding-top: $base-padding * 3
+
+  @media screen and (max-width: $break-small)
+    padding-top: $base-padding * 2
 
   .social-links
     +justify-content(flex-start)

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -175,7 +175,7 @@
     padding-left: 0
 
 .product-form
-  margin-bottom: $base-padding
+  margin-bottom: $base-padding * 2
 
 .product-form-controls
   margin-top: 0

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -536,3 +536,11 @@ _:-ms-fullscreen, :root .product-page-columns
 .related-products-title
   margin-bottom: 20px
 
+.inventory-status-message
+  display: flex
+  justify-content: center
+  align-items: center
+  color: $inventory-status-text-color
+  margin: 10px 0 auto
+  padding: 8px 0
+  font-weight: 500

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -380,7 +380,7 @@
   margin-left: auto
 
 .reset-selection-button-container
-  text-align: right
+  text-align: center
 
   button.reset-selection-button
     display: none

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -531,4 +531,4 @@ _:-ms-fullscreen, :root .product-page-columns
   height: auto
 
 .related-products-container
-  margin-top: 48px
+  margin-top: 70px

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -532,3 +532,7 @@ _:-ms-fullscreen, :root .product-page-columns
 
 .related-products-container
   margin-top: 70px
+
+.related-products-title
+  margin-bottom: 20px
+

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -417,7 +417,7 @@ ul.sort-by-nav-links
       font-size: 20px
 
 .prod-thumb-price
-  font-size: .9em
+  font-size: 0.9em
   font-weight: normal
   margin-top: $base-padding / 2
 
@@ -479,7 +479,7 @@ ul.sort-by-nav-links
 
   &.inline
     display: inline-block
-    font-size: 13px
+    font-size: 0.9rem
 
     .mobile-horizontal &
       margin-top: $base-padding
@@ -522,7 +522,7 @@ ul.sort-by-nav-links
 
     &.disabled
       cursor: not-allowed
-      opacity: .4
+      opacity: 0.4
 
     svg
       display: block
@@ -579,7 +579,7 @@ ul.sort-by-nav-links
 
   &.disabled
     cursor: not-allowed
-    opacity: .5
+    opacity: 0.5
 
   svg
     display: block


### PR DESCRIPTION
- feat: redesigned related products to use collection off product drop. 
- feat: new settings to control related products: header, number of products and sort order
- feat: redesigned style presets into 5 new categories with new styles
- feat: limited quantity messaging on product pages, behavior controlled by new settings
- feat: add categories to footer
- feat: custom footer text support
- fix: contact page name use configured name vs hardcoding
- chore: header now conditioanlly shows contact based on the `nav_items` setting as it's lower priority
- chore: homepage slideshow now autoplays by default
- chore: remove "Back to site" from global nav
- chore: styling tweaks on product page on padding and reset link centering
- chore: maintenance mode page tweaks for margin and padding