### PR TITLE
Roadie v1.13.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -60,16 +60,14 @@
         <div class="cart-actions">
           <button type="submit" name="checkout" class="button checkout-button has-right-icon">Checkout <svg aria-hidden="true" class="button-icon-right-arrow" width="21" height="20" viewBox="0 0 21 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.445798 0l9.9966372 9.99663714-.0035344.00381736.0035344.0029084L10.445798 20l-1.87436943-1.8743695L15.1964286 11.5H0v-3h15.1964286L8.57142857 1.87436946z" fill-rule="evenodd"/></svg></button>
           {% if theme.show_bnpl_messaging and cart.items != blank %}
-            {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
-              <div id="payment-processor-messaging">
-                <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
-                  <div id="paypal-messaging-element"></div>
-                </div>
-                <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
-                  <div id="payment-method-messaging-element"></div>
-                </div>
+            <div id="payment-processor-messaging">
+              <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+                <div id="paypal-messaging-element"></div>
               </div>
-            {% endunless %}
+              <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+                <div id="payment-method-messaging-element"></div>
+              </div>
+            </div>
           {% endif %}
         </div>
       </div>

--- a/source/home.html
+++ b/source/home.html
@@ -115,7 +115,15 @@
                 <div class="prod-thumb-info-headers">
                   <div class="prod-thumb-name">{{ product.name }}</div>
                   <div class="prod-thumb-price">
-                    {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% assign hide_price = false %}
+                    {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% assign hide_price = true %}
+                    {% endif -%}
+                    {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+                      {% assign hide_price = true %}
+                    {% endif %}
+
+                    {% unless hide_price %}
                       {% if product.variable_pricing %}
                         {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
                       {% else %}

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -43,9 +43,10 @@ function updateInventoryMessage(optionId = null) {
   const messageElement = document.querySelector('[data-inventory-message]') ||
   document.querySelector('.qs-modal [data-inventory-message]');
 
+  // Unlike other themes, we don't check for inventory bars as the UX in Roadie is different 
+  // allowing both low inventory messaging and inventory bars to be shown at the same time.
   if (
     !themeOptions?.showLowInventoryMessages ||
-    themeOptions.showInventoryBars ||
     !messageElement
   ) {
     return;

--- a/source/layout.html
+++ b/source/layout.html
@@ -380,7 +380,7 @@
                 </div>
               </div>
             {% endif %}
-            <div class="nav-section nav-section-credit">
+            <div class="nav-section nav-section-credit" data-bc-hook="credit">
               <div class="badge">{{ powered_by_big_cartel }}</div>
             </div>
           </nav>

--- a/source/product.html
+++ b/source/product.html
@@ -203,16 +203,14 @@
             </div>
           {% endif %}
           {% if product.status == "active" and theme.show_bnpl_messaging %}
-            {% unless theme.features.opt_outs contains "theme_bnpl_messaging" %}
-              <div id="payment-processor-messaging">
-                <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
-                  <div id="paypal-messaging-element"></div>
-                </div>
-                <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
-                  <div id="payment-method-messaging-element"></div>
-                </div>
+            <div id="payment-processor-messaging">
+              <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
+                <div id="paypal-messaging-element"></div>
               </div>
-            {% endunless %}
+              <div id="stripe-messaging-container" style="height: 0; overflow: hidden;">
+                <div id="payment-method-messaging-element"></div>
+              </div>
+            </div>
           {% endif %}
         </div>
       </form>

--- a/source/product.html
+++ b/source/product.html
@@ -11,13 +11,16 @@
 <div class="page-heading product-heading">
   <h1 class="page-title">{{ page.name }}</h1>
 </div>
-{% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
-  {% assign hide_price = true %}
-{% else %}
-  {% assign hide_price = false %}
-{% endif %}
 <div class="page-subheading{% if hide_price %} page-subheading--price-hidden{% endif %}">
   <div class="page-subheading-price">
+    {% assign hide_price = false %}
+    {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+      {% assign hide_price = true %}
+    {% endif -%}
+    {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+      {% assign hide_price = true %}
+    {% endif %}
+
     {% unless hide_price %}
       {% if product.variable_pricing %}
         {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}

--- a/source/products.html
+++ b/source/products.html
@@ -120,7 +120,15 @@
               <div class="prod-thumb-info-headers">
                 <div class="prod-thumb-name">{{ product.name }}</div>
                 <div class="prod-thumb-price">
-                  {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                  {% assign hide_price = false %}
+                  {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                    {% assign hide_price = true %}
+                  {% endif -%}
+                  {% if product.status == 'coming-soon' and theme.show_coming_soon_product_prices == false %}
+                    {% assign hide_price = true %}
+                  {% endif %}
+
+                  {% unless hide_price %}
                     {% if product.variable_pricing %}
                       {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
                     {% else %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -819,7 +819,7 @@
       "label": "Related products order",
       "type": "select",
       "options": "product_orders",
-      "default": "sales",
+      "default": "top-selling",
       "description": "The order of related products on the Product pages",
       "requires": [
         "show_related_products eq true"

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -495,29 +495,19 @@
   ],
   "options": [
     {
-      "variable": "announcement_message_text",
-      "label": "Announcement text",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 500,
-      "description": "Displays an announcement message on the top of every page"
-    },
-    {
-      "variable": "maintenance_message",
-      "label": "Maintenance mode message",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 2048,
-      "description": "A message visitors see when your shop is in Maintenance Mode",
-      "default": "We're working on our shop right now.<br /><br />Please check back soon."
-    },
-    {
-      "variable": "contact_text",
-      "label": "Contact page text",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 1024,
-      "description": "Displays a message within your contact page"
+      "variable": "logo_image_height",
+      "label": "Logo image size",
+      "section": "global_navigation",
+      "type": "select",
+      "options": [
+        ["Small", "48"],
+        ["Medium", "64"],
+        ["Large", "96"],
+        ["Extra Large", "128"],
+        ["XX Large", "160"]
+      ],
+      "default": "64",
+      "description": "Sets the height of your logo in the shop header"
     },
     {
       "variable": "store_name_heading_base_size",
@@ -536,21 +526,6 @@
       "description": "Sets the largest shop name size in the header for desktop, auto-adjusted for smaller screens."
     },
     {
-      "variable": "logo_image_height",
-      "label": "Logo image size",
-      "section": "global_navigation",
-      "type": "select",
-      "options": [
-        ["Small", "48"],
-        ["Medium", "64"],
-        ["Large", "96"],
-        ["Extra Large", "128"],
-        ["XX Large", "160"]
-      ],
-      "default": "64",
-      "description": "Sets the height of your logo in the shop header"
-    },
-    {
       "variable": "theme_layout",
       "label": "Desktop layout",
       "section": "global_navigation",
@@ -564,6 +539,14 @@
       ],
       "default": "below_header",
       "description": "Sets the overall theme layout on desktops and large screens"
+    },
+    {
+      "variable": "show_search",
+      "label": "Show search",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": true,
+      "description": "Displays a search field in the layout"
     },
     {
       "variable": "layout_style",
@@ -610,63 +593,12 @@
       "description": "Sets the position of your logo or store name"
     },
     {
-      "variable": "homepage_slideshow_autoplay",
-      "label": "Auto-play homepage slideshow",
-      "section": "homepage",
-      "type": "boolean",
-      "default": true,
-      "description": "Automatically advances slides in the homepage slideshow"
-    },
-    {
-      "variable": "homepage_slideshow_speed",
-      "label": "Slideshow speed",
-      "section": "homepage",
-      "type": "select",
-      "options": [
-        ["Slowest", 6000],
-        ["Slower", 5000],
-        ["Normal", 4000],
-        ["Faster", 3500],
-        ["Fastest", 3000]
-      ],
-      "default": 4000,
-      "description": "Controls how quickly slides advance in the auto-playing slideshow",
-      "requires": [
-        "homepage_slideshow_autoplay eq true"
-      ]
-    },
-    {
       "variable": "uppercase_text",
       "label": "Uppercase text layout",
       "section": "global_navigation",
       "type": "boolean",
       "default": false,
       "description": "Shows all text in uppercase"
-    },
-    {
-      "variable": "background_image_layout",
-      "label": "Background image layout",
-      "section": "general",
-      "type": "select",
-      "options": [
-        ["Repeating", "repeating"],
-        ["Fixed", "fixed"]
-      ],
-      "default": "fixed",
-      "description": "Sets the display of the uploaded background image"
-    },
-    {
-      "variable": "background_image_style",
-      "label": "Background image style",
-      "section": "general",
-      "type": "select",
-      "options": [
-        ["Plain image", "plain_image"],
-        ["Color overlay", "transparent_color_overlay"],
-        ["Gradient overlay", "gradient_overlay"]
-      ],
-      "default": "transparent_color_overlay",
-      "description": "Sets the overlay style when a background image is used"
     },
     {
       "variable": "show_product_grid_gutters",
@@ -728,6 +660,14 @@
       "description": "The display of your product status on the Home and Products pages"
     },
     {
+      "variable": "show_quickview",
+      "label": "Show quick view",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": false,
+      "description": "Enables quick view & buttons on product thumbnails"
+    },
+    {
       "variable": "show_overlay",
       "label": "Product grid info",
       "section": "global_navigation",
@@ -752,6 +692,70 @@
       ],
       "default": "small",
       "description": "Sets the mobile product grid style"
+    },
+    {
+      "variable": "products_per_page",
+      "label": "Products per page",
+      "section": "global_navigation",
+      "type": "select",
+      "options": "1..100",
+      "default": 48,
+      "description": "The number of products shown per page"
+    },
+    {
+      "variable": "footer_text",
+      "label": "Footer text",
+      "section": "global_navigation",
+      "type": "text",
+      "max_length": 2048,
+      "description": "Show a custom message to your shop's footer"
+    },
+    {
+      "variable": "homepage_slideshow_autoplay",
+      "label": "Auto-play homepage slideshow",
+      "section": "homepage",
+      "type": "boolean",
+      "default": true,
+      "description": "Automatically advances slides in the homepage slideshow"
+    },
+    {
+      "variable": "homepage_slideshow_speed",
+      "label": "Slideshow speed",
+      "section": "homepage",
+      "type": "select",
+      "options": [
+        ["Slowest", 6000],
+        ["Slower", 5000],
+        ["Normal", 4000],
+        ["Faster", 3500],
+        ["Fastest", 3000]
+      ],
+      "default": 4000,
+      "description": "Controls how quickly slides advance in the auto-playing slideshow",
+      "requires": [
+        "homepage_slideshow_autoplay eq true"
+      ]
+    },
+    {
+      "variable": "featured_items",
+      "label": "Featured products",
+      "section": "homepage",
+      "type": "select",
+      "options": "0..48",
+      "default": 12,
+      "description": "The number of products featured on the Home page"
+    },
+    {
+      "variable": "featured_order",
+      "label": "Featured products order",
+      "section": "homepage",
+      "type": "select",
+      "options": "product_orders",
+      "default": "position",
+      "description": "The order of products on the Home page",
+      "requires": [
+        "featured_items gt 0"
+      ]
     },
     {
       "variable": "product_image_zoom",
@@ -786,36 +790,6 @@
       ],
       "default": "show-thumbnails",
       "description": "Choose to hide or show thumbnails on the mobile Product page carousel"
-    },
-    {
-      "variable": "featured_items",
-      "label": "Featured products",
-      "section": "homepage",
-      "type": "select",
-      "options": "0..48",
-      "default": 12,
-      "description": "The number of products featured on the Home page"
-    },
-    {
-      "variable": "featured_order",
-      "label": "Featured products order",
-      "section": "homepage",
-      "type": "select",
-      "options": "product_orders",
-      "default": "position",
-      "description": "The order of products on the Home page",
-      "requires": [
-        "featured_items gt 0"
-      ]
-    },
-    {
-      "variable": "products_per_page",
-      "label": "Products per page",
-      "section": "global_navigation",
-      "type": "select",
-      "options": "1..100",
-      "default": 48,
-      "description": "The number of products shown per page"
     },
     {
       "variable": "show_related_products",
@@ -862,22 +836,6 @@
       ]
     },
     {
-      "variable": "show_quickview",
-      "label": "Show quick view",
-      "section": "global_navigation",
-      "type": "boolean",
-      "default": false,
-      "description": "Enables quick view & buttons on product thumbnails"
-    },
-    {
-      "variable": "show_search",
-      "label": "Show search",
-      "section": "global_navigation",
-      "type": "boolean",
-      "default": true,
-      "description": "Displays a search field in the layout"
-    },
-    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
       "section": "product_page",
@@ -885,23 +843,6 @@
       "default": true,
       "description": "Shows sold out product variants in the Product page dropdowns",
       "requires": ["inventory"]
-    },
-    {
-      "variable": "show_sold_out_product_prices",
-      "label": "Show prices for sold out products",
-      "section": "general",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of sold out products on product grids and product pages",
-      "requires": ["inventory"]
-    },
-    {
-      "variable": "show_coming_soon_product_prices",
-      "label": "Show prices for coming soon products",
-      "section": "general",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of coming soon products on product grids and product pages"
     },
     {
       "variable": "show_inventory_bars",
@@ -964,14 +905,6 @@
       ]
     },
     {
-      "variable": "footer_text",
-      "label": "Footer text",
-      "section": "global_navigation",
-      "type": "text",
-      "max_length": 2048,
-      "description": "Show a custom message to your shop's footer"
-    },
-    {
       "variable": "show_bnpl_messaging",
       "label": "Buy Now, Pay Later Messaging",
       "section": "product_page",
@@ -981,6 +914,48 @@
       "requires": [
         "feature:theme_bnpl_messaging neq opted_out"
       ]
+    },
+    {
+      "variable": "background_image_layout",
+      "label": "Background image layout",
+      "section": "general",
+      "type": "select",
+      "options": [
+        ["Repeating", "repeating"],
+        ["Fixed", "fixed"]
+      ],
+      "default": "fixed",
+      "description": "Sets the display of the uploaded background image"
+    },
+    {
+      "variable": "background_image_style",
+      "label": "Background image style",
+      "section": "general",
+      "type": "select",
+      "options": [
+        ["Plain image", "plain_image"],
+        ["Color overlay", "transparent_color_overlay"],
+        ["Gradient overlay", "gradient_overlay"]
+      ],
+      "default": "transparent_color_overlay",
+      "description": "Sets the overlay style when a background image is used"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "section": "general",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of sold out products on product grids and product pages",
+      "requires": ["inventory"]
+    },
+    {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "section": "general",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
     },
     {
       "variable": "money_format",
@@ -993,6 +968,31 @@
       ],
       "default": "sign",
       "description": "Sets the display of prices in your shop"
+    },
+    {
+      "variable": "announcement_message_text",
+      "label": "Announcement text",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 500,
+      "description": "Displays an announcement message on the top of every page"
+    },
+    {
+      "variable": "maintenance_message",
+      "label": "Maintenance mode message",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 2048,
+      "description": "A message visitors see when your shop is in Maintenance Mode",
+      "default": "We're working on our shop right now.<br /><br />Please check back soon."
+    },
+    {
+      "variable": "contact_text",
+      "label": "Contact page text",
+      "section": "messaging",
+      "type": "text",
+      "max_length": 1024,
+      "description": "Displays a message within your contact page"
     },
     {
       "variable": "instagram_url",

--- a/source/settings.json
+++ b/source/settings.json
@@ -856,8 +856,7 @@
       "default": true,
       "description": "Show shoppers alerts on Product pages when it's running low on stock",
       "requires": [
-        "inventory",
-        "show_inventory_bars eq false"
+        "inventory"
       ]
     },
     {
@@ -869,7 +868,6 @@
       "description": "When stock drops below this number, shoppers will see low stock message. 'Almost sold out' message shows at half this amount",
       "requires": [
         "inventory",
-        "show_inventory_bars eq false",
         "show_low_inventory_messages eq true"
       ]
     },
@@ -882,7 +880,6 @@
       "default": "Limited quantities available",
       "requires": [
         "inventory",
-        "show_inventory_bars eq false",
         "show_low_inventory_messages eq true"
       ]
     },
@@ -895,7 +892,6 @@
       "default": "Only a few left!",
       "requires": [
         "inventory",
-        "show_inventory_bars eq false",
         "show_low_inventory_messages eq true",
         "low_inventory_threshold gt 1"
       ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -762,7 +762,7 @@
       "variable": "featured_items",
       "label": "Featured products",
       "type": "select",
-      "options": "0..100",
+      "options": "0..48",
       "default": 12,
       "description": "The number of products featured on the Home page"
     },
@@ -854,6 +854,13 @@
       "default": true,
       "description": "Show the price of sold out products on product grids and product pages",
       "requires": ["inventory"]
+    },
+    {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
     },
     {
       "variable": "show_inventory_bars",

--- a/source/settings.json
+++ b/source/settings.json
@@ -908,7 +908,10 @@
       "label": "Buy Now, Pay Later Messaging",
       "type": "boolean",
       "default": true,
-      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan."
+      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
+      "requires": [
+        "feature:theme_bnpl_messaging neq opted_out"
+      ]
     },
     {
       "variable": "money_format",

--- a/source/settings.json
+++ b/source/settings.json
@@ -913,7 +913,8 @@
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
       "requires": [
         "feature:theme_bnpl_messaging neq opted_out"
-      ]
+      ],
+      "plan_type": "paid"
     },
     {
       "variable": "background_image_layout",

--- a/source/settings.json
+++ b/source/settings.json
@@ -5,16 +5,19 @@
     {
       "variable": "logo",
       "label": "Logo",
+      "section": "global_navigation",
       "description": "Adds your logo to the header or sidebar"
     },
     {
       "variable": "background_image",
       "label": "Background Image",
+      "section": "general",
       "description": "Adds a fixed or repeating background image"
     },
     {
       "variable": "promo_image",
       "label": "Promo Image",
+      "section": "homepage",
       "description": "Adds an image to the Home page"
     }
   ],
@@ -22,6 +25,7 @@
     {
       "variable": "slideshow",
       "label": "Slideshow",
+      "section": "homepage",
       "description": "Adds a slideshow to your Home page. 900 x 500 images recommended. Overrides promo image if both are set."
     }
   ],
@@ -493,6 +497,7 @@
     {
       "variable": "announcement_message_text",
       "label": "Announcement text",
+      "section": "messaging",
       "type": "text",
       "max_length": 500,
       "description": "Displays an announcement message on the top of every page"
@@ -500,6 +505,7 @@
     {
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
+      "section": "messaging",
       "type": "text",
       "max_length": 2048,
       "description": "A message visitors see when your shop is in Maintenance Mode",
@@ -508,6 +514,7 @@
     {
       "variable": "contact_text",
       "label": "Contact page text",
+      "section": "messaging",
       "type": "text",
       "max_length": 1024,
       "description": "Displays a message within your contact page"
@@ -515,6 +522,7 @@
     {
       "variable": "store_name_heading_base_size",
       "label": "Shop name heading size",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Smallest", "40"],
@@ -530,6 +538,7 @@
     {
       "variable": "logo_image_height",
       "label": "Logo image size",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Small", "48"],
@@ -544,6 +553,7 @@
     {
       "variable": "theme_layout",
       "label": "Desktop layout",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Navigation above header", "above_header"],
@@ -558,6 +568,7 @@
     {
       "variable": "layout_style",
       "label": "Desktop layout style",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Fixed width", "fixed-width"],
@@ -569,6 +580,7 @@
     {
       "variable": "show_layout_gutters",
       "label": "Enable layout margins",
+      "section": "global_navigation",
       "type": "boolean",
       "default": true,
       "description": "Adds spacing to the left/right edges of the layout (smaller screens and full width layouts)"
@@ -576,6 +588,7 @@
     {
       "variable": "sidebar_position",
       "label": "Sidebar & product details",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Left align", "left"],
@@ -587,6 +600,7 @@
     {
       "variable": "header_position",
       "label": "Header position",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Left", "left"],
@@ -598,6 +612,7 @@
     {
       "variable": "homepage_slideshow_autoplay",
       "label": "Auto-play homepage slideshow",
+      "section": "homepage",
       "type": "boolean",
       "default": true,
       "description": "Automatically advances slides in the homepage slideshow"
@@ -605,6 +620,7 @@
     {
       "variable": "homepage_slideshow_speed",
       "label": "Slideshow speed",
+      "section": "homepage",
       "type": "select",
       "options": [
         ["Slowest", 6000],
@@ -622,6 +638,7 @@
     {
       "variable": "uppercase_text",
       "label": "Uppercase text layout",
+      "section": "global_navigation",
       "type": "boolean",
       "default": false,
       "description": "Shows all text in uppercase"
@@ -629,6 +646,7 @@
     {
       "variable": "background_image_layout",
       "label": "Background image layout",
+      "section": "general",
       "type": "select",
       "options": [
         ["Repeating", "repeating"],
@@ -640,6 +658,7 @@
     {
       "variable": "background_image_style",
       "label": "Background image style",
+      "section": "general",
       "type": "select",
       "options": [
         ["Plain image", "plain_image"],
@@ -652,6 +671,7 @@
     {
       "variable": "show_product_grid_gutters",
       "label": "Enable product grid spacing",
+      "section": "global_navigation",
       "type": "boolean",
       "default": true,
       "description": "Adds spacing around the sides of product thumbnails"
@@ -659,6 +679,7 @@
     {
       "variable": "product_list_layout",
       "label": "Product grid layout",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Rows", "rows"],
@@ -670,6 +691,7 @@
     {
       "variable": "product_grid_image_size",
       "label": "Product grid image size",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Small", "small"],
@@ -682,6 +704,7 @@
     {
       "variable": "grid_image_style",
       "label": "Product grid image style",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Default", "default"],
@@ -694,6 +717,7 @@
     {
       "variable": "product_badge_style",
       "label": "Product grid badges",
+      "section": "global_navigation",
       "type": "select",
       "options": [
           ["Bar", "bar"],
@@ -706,6 +730,7 @@
     {
       "variable": "show_overlay",
       "label": "Product grid info",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["Show on hover", "rollover"],
@@ -718,6 +743,7 @@
     {
       "variable": "mobile_product_grid_style",
       "label": "Mobile product grid style",
+      "section": "global_navigation",
       "type": "select",
       "options": [
         ["1 product across", "medium"],
@@ -730,6 +756,7 @@
     {
       "variable": "product_image_zoom",
       "label": "Enable product image zoom",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Click to open a larger version of the Product page image"
@@ -737,6 +764,7 @@
     {
       "variable": "desktop_product_page_images",
       "label": "Desktop product page images",
+      "section": "product_page",
       "type": "select",
       "options": [
         ["Thumbnails", "thumbnails"],
@@ -750,6 +778,7 @@
     {
       "variable": "mobile_product_page_images",
       "label": "Mobile product page image carousel",
+      "section": "product_page",
       "type": "select",
       "options": [
         ["Show thumbnails", "show-thumbnails"],
@@ -761,6 +790,7 @@
     {
       "variable": "featured_items",
       "label": "Featured products",
+      "section": "homepage",
       "type": "select",
       "options": "0..48",
       "default": 12,
@@ -769,6 +799,7 @@
     {
       "variable": "featured_order",
       "label": "Featured products order",
+      "section": "homepage",
       "type": "select",
       "options": "product_orders",
       "default": "position",
@@ -780,6 +811,7 @@
     {
       "variable": "products_per_page",
       "label": "Products per page",
+      "section": "global_navigation",
       "type": "select",
       "options": "1..100",
       "default": 48,
@@ -788,6 +820,7 @@
     {
       "variable": "show_related_products",
       "label": "Show related products",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Display recommended products on Product pages starting with same category"
@@ -795,6 +828,7 @@
     {
       "variable": "number_related_products",
       "label": "Number of related products",
+      "section": "product_page",
       "type": "select",
       "options": "1..8",
       "default": 3,
@@ -806,6 +840,7 @@
     {
       "variable": "related_products_header",
       "label": "Related products header",
+      "section": "product_page",
       "type": "text",
       "max_length": 75,
       "description": "Displays above related products on Products pages",
@@ -817,6 +852,7 @@
     {
       "variable": "related_products_order",
       "label": "Related products order",
+      "section": "product_page",
       "type": "select",
       "options": "product_orders",
       "default": "top-selling",
@@ -828,6 +864,7 @@
     {
       "variable": "show_quickview",
       "label": "Show quick view",
+      "section": "global_navigation",
       "type": "boolean",
       "default": false,
       "description": "Enables quick view & buttons on product thumbnails"
@@ -835,6 +872,7 @@
     {
       "variable": "show_search",
       "label": "Show search",
+      "section": "global_navigation",
       "type": "boolean",
       "default": true,
       "description": "Displays a search field in the layout"
@@ -842,6 +880,7 @@
     {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Shows sold out product variants in the Product page dropdowns",
@@ -850,6 +889,7 @@
     {
       "variable": "show_sold_out_product_prices",
       "label": "Show prices for sold out products",
+      "section": "general",
       "type": "boolean",
       "default": true,
       "description": "Show the price of sold out products on product grids and product pages",
@@ -858,6 +898,7 @@
     {
       "variable": "show_coming_soon_product_prices",
       "label": "Show prices for coming soon products",
+      "section": "general",
       "type": "boolean",
       "default": true,
       "description": "Show the price of coming soon products on product grids and product pages"
@@ -865,6 +906,7 @@
     {
       "variable": "show_inventory_bars",
       "label": "Show inventory bars",
+      "section": "product_page",
       "type": "boolean",
       "default": false,
       "description": "Shows a product's inventory amounts (when using inventory tracking)",
@@ -873,6 +915,7 @@
     {
       "variable": "show_low_inventory_messages",
       "label": "Show product stock alerts",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Show shoppers alerts on Product pages when it's running low on stock",
@@ -883,6 +926,7 @@
     {
       "variable": "low_inventory_threshold",
       "label": "Low stock alert",
+      "section": "product_page",
       "options": "1..100",
       "type": "select",
       "default": "10",
@@ -895,6 +939,7 @@
     {
       "variable": "low_inventory_message",
       "label": "Low stock message",
+      "section": "product_page",
       "type": "text",
       "max_length": 50,
       "description": "Message shown when stock drops below your alert level",
@@ -907,6 +952,7 @@
     {
       "variable": "almost_sold_out_message",
       "label": "Almost sold out message",
+      "section": "product_page",
       "type": "text",
       "max_length": 50,
       "description": "Message shown when stock drops below half your alert level",
@@ -920,6 +966,7 @@
     {
       "variable": "footer_text",
       "label": "Footer text",
+      "section": "global_navigation",
       "type": "text",
       "max_length": 2048,
       "description": "Show a custom message to your shop's footer"
@@ -927,6 +974,7 @@
     {
       "variable": "show_bnpl_messaging",
       "label": "Buy Now, Pay Later Messaging",
+      "section": "product_page",
       "type": "boolean",
       "default": true,
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
@@ -937,6 +985,7 @@
     {
       "variable": "money_format",
       "label": "Price display",
+      "section": "general",
       "type": "select",
       "options": [
         ["Currency sign", "sign"],
@@ -948,84 +997,98 @@
     {
       "variable": "instagram_url",
       "label": "Instagram URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://instagram.com/bigcartel"
     },
     {
       "variable": "tiktok_url",
       "label": "TikTok URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://tiktok.com/@bigcartelofficial"
     },
     {
       "variable": "bluesky_url",
       "label": "Bluesky URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bsky.app/profile/bigcartel.com"
     },
     {
       "variable": "threads_url",
       "label": "Threads URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://threads.net/@bigcartel"
     },
     {
       "variable": "twitter_url",
       "label": "X URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://x.com/bigcartel"
     },
     {
       "variable": "facebook_url",
       "label": "Facebook URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://facebook.com/bigcartel"
     },
     {
       "variable": "snapchat_url",
       "label": "Snapchat URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://snapchat.com/add/bigcartel"
     },
     {
       "variable": "pinterest_url",
       "label": "Pinterest URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://pinterest.com/big_cartel"
     },
     {
       "variable": "youtube_url",
       "label": "YouTube URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://youtube.com/@BigCartelDotCom"
     },
     {
       "variable": "spotify_url",
       "label": "Spotify URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://open.spotify.com/artist/0gxy..."
     },
     {
       "variable": "linkedin_url",
       "label": "LinkedIn URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://linkedin.com/in/bigcartel"
     },
     {
       "variable": "twitch_url",
       "label": "Twitch URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://twitch.tv/username"
     },
     {
       "variable": "tumblr_url",
       "label": "Tumblr URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bigcartel.tumblr.com"
     },
     {
       "variable": "bandcamp_url",
       "label": "Bandcamp URL",
+      "section": "social",
       "type": "text",
       "description": "Ex: https://bigcartel.bandcamp.com"
     }

--- a/source/settings.json
+++ b/source/settings.json
@@ -912,7 +912,7 @@
       "default": true,
       "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
       "requires": [
-        "feature:theme_bnpl_messaging neq opted_out"
+        "feature:theme_bnpl_messaging eq visible"
       ],
       "plan_type": "paid"
     },

--- a/source/settings.json
+++ b/source/settings.json
@@ -528,6 +528,20 @@
       "description": "Sets the largest shop name size in the header for desktop, auto-adjusted for smaller screens."
     },
     {
+      "variable": "logo_image_height",
+      "label": "Logo image size",
+      "type": "select",
+      "options": [
+        ["Small", "48"],
+        ["Medium", "64"],
+        ["Large", "96"],
+        ["Extra Large", "128"],
+        ["XX Large", "160"]
+      ],
+      "default": "64",
+      "description": "Sets the height of your logo in the shop header"
+    },
+    {
       "variable": "theme_layout",
       "label": "Desktop layout",
       "type": "select",

--- a/source/stylesheets/_variables.sass
+++ b/source/stylesheets/_variables.sass
@@ -10,6 +10,8 @@ $border-color: #{"{{ theme.border_color }}"}
 
 $store-name-heading-size-numeric: #{"{{ theme.store_name_heading_base_size }}"}
 
+$logo-max-height-numeric: #{"{{ theme.logo_image_height }}"}
+
 $button-text-color: #{"{{ theme.button_text_color }}"}
 $button-background-color: #{"{{ theme.button_background_color }}"}
 

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -322,8 +322,7 @@ header
     max-width: 100%
 
     @media screen and (min-width: $break-small + 1)
-      height: 64px
-
+      height: calc(#{$logo-max-height-numeric} * 1px)
       .above-header &
         height: 180px
         width: 100%
@@ -342,10 +341,9 @@ header
         .store-logo
           height: 100%
           width: 100%
-
+      
     @media screen and (max-width: $break-small)
-      height: auto
-      max-height: 50px
+      height: clamp(50px, calc((#{$logo-max-height-numeric} * 0.75) * 1px), 96px)
 
   .header-left-align &
     text-align: left

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -426,7 +426,7 @@ ul.sort-by-nav-links
       font-size: 16px
 
 .prod-thumb-status
-  font-weight: bold
+  font-weight: normal
 
   &.circle
     +flexbox


### PR DESCRIPTION
- feat: setting to hide coming soon products
- feat: logo height setting
- chore: remove unnecessary bnpl feature flag check 
- chore: show low inventory messages even if inventory bars enabled 
- chore: bnpl messaging depends on feature flag
- chore: version bump roadie 1.13.0
- chore: product status normal font weight
- chore: add `data-bc-hook` for credit
- chore: use correct product ordering keyword for related products
- chore: add `section` prop values to each theme option setting
- chore: reorder theme settings options based on `section` prop
- chore: add `plan_type` prop to bnpl setting for future use
- chore: use new feature flag format for visibility