### PR TITLE
Roadie 1.15.1

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -213,7 +213,7 @@
                       {% endfor %}
                     {% endif %}
                     {% if theme.nav_page_display == 'all' or theme.nav_page_display == 'contact_only' %}
-                      <li class="nav-menu-item" role="menuitem" aria-haspopup="false"><a href="/contact"><span class="hover-underline no-underline">{{ t['navigation.contact'] }}}</span></a></li>
+                      <li class="nav-menu-item" role="menuitem" aria-haspopup="false"><a href="/contact"><span class="hover-underline no-underline">{{ t['navigation.contact'] }}</span></a></li>
                     {% endif %}
                   {% else %}
                     <li class="nav-menu-item" role="menuitem" aria-haspopup="true">

--- a/source/settings.json
+++ b/source/settings.json
@@ -1556,6 +1556,7 @@
       "section": "translations",
       "sub_section": "cart",
       "type": "text",
+      "max_length": 250,
       "default": "Your cart is empty",
       "description": "Text for the empty cart message",
       "requires": [ "translation_mode eq manual" ]

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Roadie",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
- fix: removed errant `}` for "Contact" nav entry
- chore: allow for longer manual empty cart text translation (30 -> 250 chars)